### PR TITLE
Allow publish pyfunc and pyspark docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,6 @@ jobs:
 
   publish-pyfunc-base-docker:
     runs-on: ubuntu-latest
-    needs: publish-python-sdk
     steps:
       - uses: actions/checkout@v2
       - name: Build and push PyFunc Base Docker image
@@ -148,7 +147,6 @@ jobs:
 
   publish-pyspark-base-docker:
     runs-on: ubuntu-latest
-    needs: publish-python-sdk
     steps:
       - uses: actions/checkout@v2
       - name: Build and push PySpark Base Docker image


### PR DESCRIPTION
Publish python sdk no longer becomes the requirements for publishing the pyfunc and pyspark docker image