### PR TITLE
InferenceService URL as target host of Model VS

### DIFF
--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -74,6 +74,19 @@ func (e *VersionEndpoint) IsServing() bool {
 	return e.Status == EndpointServing
 }
 
+func (e *VersionEndpoint) HostURL() string {
+	if e.Url == "" {
+		return ""
+	}
+
+	url, err := url.Parse(e.Url)
+	if err != nil {
+		return ""
+	}
+
+	return url.Hostname()
+}
+
 type EndpointMonitoringURLParams struct {
 	Cluster      string
 	Project      string

--- a/api/models/version_endpoint_test.go
+++ b/api/models/version_endpoint_test.go
@@ -17,10 +17,9 @@ package models
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/gojek/merlin/config"
 	"github.com/gojek/merlin/mlp"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionEndpoint(t *testing.T) {
@@ -125,6 +124,49 @@ func TestVersionEndpoint_UpdateMonitoringUrl(t *testing.T) {
 			e.UpdateMonitoringUrl(tt.args.baseURL, tt.args.params)
 
 			assert.Equal(t, tt.want, e.MonitoringUrl)
+		})
+	}
+}
+
+func TestVersionEndpoint_HostURL(t *testing.T) {
+	type fields struct {
+		Url string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			"empty url",
+			fields{
+				Url: "",
+			},
+			"",
+		},
+		{
+			"https://gojek.com",
+			fields{
+				Url: "https://gojek.com",
+			},
+			"gojek.com",
+		},
+		{
+			"https://gojek.com/v1/models/gojek-1:predict",
+			fields{
+				Url: "https://gojek.com/v1/models/gojek-1:predict",
+			},
+			"gojek.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &VersionEndpoint{
+				Url: tt.fields.Url,
+			}
+			if got := e.HostURL(); got != tt.want {
+				t.Errorf("VersionEndpoint.HostURL() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/api/service/model_endpoint_service.go
+++ b/api/service/model_endpoint_service.go
@@ -261,7 +261,7 @@ func (s *modelEndpointsService) createVirtualService(model *models.Model, endpoi
 			},
 			Headers: &networking.Headers{
 				Request: &networking.Headers_HeaderOperations{
-					Set: map[string]string{"Host": versionEndpoint.ServiceName},
+					Set: map[string]string{"Host": versionEndpoint.HostURL()},
 				},
 			},
 			Weight: destination.Weight,

--- a/api/service/model_endpoint_service_test.go
+++ b/api/service/model_endpoint_service_test.go
@@ -176,7 +176,7 @@ func Test_createVirtualService(t *testing.T) {
 									},
 									Headers: &networking.Headers{
 										Request: &networking.Headers_HeaderOperations{
-											Set: map[string]string{"Host": versionEndpoint1.ServiceName},
+											Set: map[string]string{"Host": versionEndpoint1.HostURL()},
 										},
 									},
 									Weight: 100,


### PR DESCRIPTION
Previously, we use InferenceService Predictor URL for Model Endpoint VirtualService target host when serving traffic to model version.
E.g., when we serve model version 1, we will have this URL (model-version-1-predictor-default.domain.com) as host.

The problem would arise if we deploy a model with a transformer. If we keep using Predictor URL as Host, we will skip sending requests to the Transformer. To fix it, we can do one of these:
1. Check if transformer exists, then use Transformer URL as Model Endpoint VirtualService host, or
2. Use InferenceService Host URL, e.g. (model-version-1.domain.com)

This PR uses option #2.