### PR TITLE
Reduce required python version to run Merlin SDK

### DIFF
--- a/python/batch-predictor/setup.py
+++ b/python/batch-predictor/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email='merlin-dev@gojek.com',
     description='Base pyspark application for running merlin prediction job',
     long_description=open('README.md').read(),
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     packages=find_packages("merlinpyspark"),
     install_requires=REQUIRE,
     tests_require=TEST_REQUIRE,

--- a/python/pyfunc-server/setup.py
+++ b/python/pyfunc-server/setup.py
@@ -26,7 +26,7 @@ setup(
     description='Model Server implementation for mlflow pyfunc model. \
                  Not intended for use outside KFServing Frameworks Images',
     long_description=open('README.md').read(),
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     packages=find_packages("pyfuncserver"),
     install_requires=[
         "kfserving==0.2.1.1",

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -61,7 +61,7 @@ setup(
     setup_requires=["setuptools_scm"],
     tests_require=TEST_REQUIRES,
     extras_require={'test': TEST_REQUIRES},
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     entry_points='''
         [console_scripts]
         merlin=merlin.merlin:cli


### PR DESCRIPTION
**What this PR does / why we need it**:
Some of the clients are still using the old version of Python and it would be not straightforward for them to update their Python version.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
