### PR TITLE
[SDK] Fix validation for model name

### DIFF
--- a/python/sdk/merlin/client.py
+++ b/python/sdk/merlin/client.py
@@ -177,7 +177,7 @@ class MerlinClient:
         :param model_type: model type
         :return: Model
         """
-        if not valid_name_check(project_name):
+        if not valid_name_check(model_name):
             raise ValueError(
                 '''Your project/model name contains invalid characters.\
                     \nUse only the following characters\

--- a/python/sdk/test/client_test.py
+++ b/python/sdk/test/client_test.py
@@ -87,7 +87,7 @@ def test_create_invalid_project_name(mock_url, api_client, mock_oauth, use_googl
 
     client = MerlinClient(mock_url, use_google_oauth=use_google_oauth)
 
-    # Try to undeploy serving model version. It must be fail
+    # Try to create project with invalid name. It must be fail
     with pytest.raises(Exception):
         assert client.get_project(project_name)
 
@@ -157,7 +157,7 @@ def test_create_invalid_model_name(mock_url, api_client, mock_oauth, use_google_
 
     client = MerlinClient(mock_url, use_google_oauth=use_google_oauth)
 
-    # Try to undeploy serving model version. It must be fail
+    # Try to create model with invalid name. It must be fail
     with pytest.raises(Exception):
         assert client.get_or_create_model(model_name, project_name, model_type)
 

--- a/python/sdk/test/client_test.py
+++ b/python/sdk/test/client_test.py
@@ -80,6 +80,18 @@ def test_get_project(mock_url, mock_oauth, use_google_oauth):
     assert isinstance(p.created_at, datetime.datetime)
     assert isinstance(p.updated_at, datetime.datetime)
 
+
+@responses.activate
+def test_create_invalid_project_name(mock_url, api_client, mock_oauth, use_google_oauth):
+    project_name = "invalidProjectName"
+
+    client = MerlinClient(mock_url, use_google_oauth=use_google_oauth)
+
+    # Try to undeploy serving model version. It must be fail
+    with pytest.raises(Exception):
+        assert client.get_project(project_name)
+
+
 @responses.activate
 def test_create_model(mock_url, api_client, mock_oauth, use_google_oauth):
     project_id = '1010'
@@ -135,6 +147,19 @@ def test_create_model(mock_url, api_client, mock_oauth, use_google_oauth):
         assert isinstance(model.created_at, datetime.datetime)
         assert isinstance(model.updated_at, datetime.datetime)
         assert model.project == project
+
+
+@responses.activate
+def test_create_invalid_model_name(mock_url, api_client, mock_oauth, use_google_oauth):
+    model_name = "invalidModelName"
+    project_name = "my-project"
+    model_type = ModelType.XGBOOST
+
+    client = MerlinClient(mock_url, use_google_oauth=use_google_oauth)
+
+    # Try to undeploy serving model version. It must be fail
+    with pytest.raises(Exception):
+        assert client.get_or_create_model(model_name, project_name, model_type)
 
 
 @responses.activate


### PR DESCRIPTION
**What this PR does / why we need it**:

The validation of the model name in `merlin.set_model()` is not working as expected due to the wrong variable passed.

**Checklist**

- [x] Tested locally