### PR TITLE
Fix disable merlin transformer

### DIFF
--- a/api/cluster/resource.go
+++ b/api/cluster/resource.go
@@ -89,6 +89,8 @@ func patchInferenceServiceSpec(orig *kfsv1alpha2.InferenceService, modelService 
 	labels := createLabels(modelService)
 	orig.ObjectMeta.Labels = labels
 	orig.Spec.Default.Predictor = createPredictorSpec(modelService, config)
+
+	orig.Spec.Default.Transformer = nil
 	if modelService.Transformer != nil && modelService.Transformer.Enabled {
 		orig.Spec.Default.Transformer = createTransformerSpec(modelService, modelService.Transformer, config)
 	}

--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -109,7 +109,7 @@ func (k *endpointService) DeployEndpoint(environment *models.Environment, model 
 		endpoint.ResourceRequest = newEndpoint.ResourceRequest
 	}
 
-	if newEndpoint.Transformer != nil && newEndpoint.Transformer.Enabled {
+	if newEndpoint.Transformer != nil {
 		endpoint.Transformer = newEndpoint.Transformer
 		endpoint.Transformer.VersionEndpointID = endpoint.Id
 	}

--- a/api/service/version_endpoint_service_test.go
+++ b/api/service/version_endpoint_service_test.go
@@ -22,18 +22,16 @@ import (
 	"testing"
 	"time"
 
-	clusterMock "github.com/gojek/merlin/cluster/mocks"
-	imageBuilderMock "github.com/gojek/merlin/imagebuilder/mocks"
-	"github.com/gojek/merlin/mlp"
-
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/gojek/merlin/cluster"
+	clusterMock "github.com/gojek/merlin/cluster/mocks"
 	"github.com/gojek/merlin/config"
+	imageBuilderMock "github.com/gojek/merlin/imagebuilder/mocks"
+	"github.com/gojek/merlin/mlp"
 	"github.com/gojek/merlin/models"
 	"github.com/gojek/merlin/storage/mocks"
 )
@@ -261,6 +259,10 @@ func TestDeployEndpoint(t *testing.T) {
 				assert.Equal(t, models.EndpointRunning, savedEndpoint.Status)
 				assert.Equal(t, url, savedEndpoint.Url)
 				assert.Equal(t, iSvcName, savedEndpoint.InferenceServiceName)
+			}
+
+			if tt.args.endpoint.Transformer != nil {
+				assert.Equal(t, tt.args.endpoint.Transformer.Enabled, e.Transformer.Enabled)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
There's an issue with the redeployment of a model version with an enabled transformer. When the user tries to disable a transformer using Model Version Endpoint Redeploy API, the model version will still have the transformer enabled. This is due to unhandled logic inside the API/

**Which issue(s) this PR fixes**:
This PR fixes the issue describes above.

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally