### PR TITLE
Use table for displaying environment variables in version UI page

### DIFF
--- a/ui/src/components/EnvVarsConfigTable.js
+++ b/ui/src/components/EnvVarsConfigTable.js
@@ -16,22 +16,34 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { EuiDescriptionList, EuiText } from "@elastic/eui";
+import { EuiInMemoryTable, EuiText } from "@elastic/eui";
 
 export const EnvVarsConfigTable = ({ variables }) => {
-  const items = variables.map(v => ({
-    title: v.name,
-    description: v.value
-  }));
+  const columns = [
+    {
+      field: "name",
+      name: "Name",
+      width: "20%",
+      sortable: true
+    },
+    {
+      field: "value",
+      name: "Value",
+      width: "80%",
+      sortable: true
+    }
+  ];
+
+  const sorting = {
+    enableAllColumns: true
+  };
 
   return variables.length ? (
-    <EuiDescriptionList
-      compressed
-      textStyle="reverse"
-      type="responsiveColumn"
-      listItems={items}
-      titleProps={{ style: { width: "30%" } }}
-      descriptionProps={{ style: { width: "70%" } }}
+    <EuiInMemoryTable
+      items={variables}
+      columns={columns}
+      itemId="name"
+      sorting={sorting}
     />
   ) : (
     <EuiText size="s" color="subdued">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

We are using EuiDescriptionList to display the model and transformer's environment variables. However, if the value of env var is too long, the Description List's width is expanded and growing as long as the content. This PR uses Table to display the env var.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Tested locally
