### PR TITLE
Append :predict in version endpoint url

### DIFF
--- a/python/sdk/merlin/endpoint.py
+++ b/python/sdk/merlin/endpoint.py
@@ -31,7 +31,10 @@ class Status(Enum):
 @autostr
 class VersionEndpoint:
     def __init__(self, endpoint: client.VersionEndpoint, log_url: str = None):
-        self._url = f"{endpoint.url}:predict"
+        self._url = f"{endpoint.url}"
+        if ":predict" not in endpoint.url:
+            self._url = f"{endpoint.url}:predict"
+
         self._status = Status(endpoint.status)
         self._id = endpoint.id
         self._environment_name = endpoint.environment_name

--- a/ui/src/pages/version/DeploymentPanelHeader.js
+++ b/ui/src/pages/version/DeploymentPanelHeader.js
@@ -24,6 +24,7 @@ import { DeploymentStatus } from "../../components/DeploymentStatus";
 import { HorizontalDescriptionList } from "../../components/HorizontalDescriptionList";
 import { DeploymentActions } from "./DeploymentActions";
 import { EnvironmentDropdown } from "./EnvironmentDropdown";
+import { versionEndpointUrl } from "../../utils/versionEndpointUrl";
 
 export const DeploymentPanelHeader = ({
   model,
@@ -59,7 +60,7 @@ export const DeploymentPanelHeader = ({
     {
       title: "Endpoint",
       description: endpoint ? (
-        <CopyableUrl text={endpoint.url} />
+        <CopyableUrl text={versionEndpointUrl(endpoint.url)} />
       ) : (
         <EuiText>-</EuiText>
       ),

--- a/ui/src/utils/versionEndpointUrl.js
+++ b/ui/src/utils/versionEndpointUrl.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 The Merlin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PropTypes from "prop-types";
+
+export const versionEndpointUrl = url => {
+  return url.includes(":predict") ? url : url + ":predict";
+};
+
+versionEndpointUrl.propTypes = {
+  url: PropTypes.string.isRequired
+};


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

The model version UI page displays and uses incorrect Version Endpoint URL, which is missing `:predict` in the URL. This PR fixes the Version Endpoint URL to be displayed and copied.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Tested locally
