### PR TITLE
Make boto3 version dependency more flexible

### DIFF
--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -26,7 +26,7 @@ REQUIRES = [
     "six>=1.10",
     "mlflow>=1.2.0",
     "google-cloud-storage>=1.19.0",
-    "boto3==1.9.84",
+    "boto3>=1.9.84",
     "urllib3>=1.23",
     "PyPrind>=2.11.2",
     "google-auth>=1.11.0,<2.0dev",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

`boto3` version for merlin-sdk is locked to `1.9.84`. This locking can leads to unintended effects when user needs another version of boto3.

