### PR TITLE
Bump python sdk version

### DIFF
--- a/python/batch-predictor/requirements.txt
+++ b/python/batch-predictor/requirements.txt
@@ -2,5 +2,5 @@ pyspark==2.4.5
 mlflow==1.6.0
 cloudpickle==1.2.2
 pyarrow==0.14.1
-merlin-sdk==0.9.0.dev0
+merlin-sdk==0.9.1
 protobuf>=3.0

--- a/python/pyfunc-server/setup.py
+++ b/python/pyfunc-server/setup.py
@@ -34,7 +34,7 @@ setup(
         "numpy >= 1.8.2",
         "mlflow==1.6.0",
         "cloudpickle==1.2.2",
-        "merlin-sdk==0.9.0.dev0",
+        "merlin-sdk==0.9.1",
         "prometheus_client==0.7.1",
         "uvloop>=0.14.0",
         "orjson==2.6.8"

--- a/python/sdk/merlin/version.py
+++ b/python/sdk/merlin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.9.0.dev0"
+VERSION = "0.9.1"


### PR DESCRIPTION


**What this PR does / why we need it**:
In the previous [PR](https://github.com/gojek/merlin/pull/40) we introduce changes on sdk but forgot to bump its version. Hence in this PR we bump version of sdk
