### PR TITLE
Refactor how to build feast request to support multiple entities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
           registry: ghcr.io
           repository: gojek/merlin-transformer
           build_args: BRANCH=${{ github.ref }},REVISION=${{ github.sha }},VERSION=${{ github.ref }}
+          dockerfile: transformer.Dockerfile
           tag_with_ref: true
 
   publish-pyfunc-base-docker:

--- a/api/pkg/transformer/feast/transformer.go
+++ b/api/pkg/transformer/feast/transformer.go
@@ -138,18 +138,9 @@ func (t *Transformer) Transform(ctx context.Context, request []byte) ([]byte, er
 }
 
 func (t *Transformer) getFeastFeature(ctx context.Context, request []byte, config *transformer.FeatureTable) (*FeastFeature, error) {
-	var entities []feast.Row
-	for _, entity := range config.Entities {
-		vals, err := getValuesFromJSONPayload(request, entity)
-		if err != nil {
-			return nil, fmt.Errorf("unable to extract entity %s: %v", entity.Name, err)
-		}
-
-		for _, val := range vals {
-			entities = append(entities, feast.Row{
-				entity.Name: val,
-			})
-		}
+	entities, err := buildEntitiesRequest(request, config.Entities)
+	if err != nil {
+		return nil, err
 	}
 
 	var features []string
@@ -217,7 +208,7 @@ func (t *Transformer) getFeastFeature(ctx context.Context, request []byte, confi
 				}
 				row = append(row, featVal)
 			default:
-				return nil, fmt.Errorf("")
+				return nil, fmt.Errorf("Unsupported feature retrieval status: %s", featureStatus)
 			}
 			// put behind feature toggle since it will generate high cardinality metrics
 			if t.options.StatusMonitoringEnabled {
@@ -233,6 +224,51 @@ func (t *Transformer) getFeastFeature(ctx context.Context, request []byte, confi
 	}, nil
 }
 
+func buildEntitiesRequest(request []byte, configEntities []*transformer.Entity) ([]feast.Row, error) {
+	allEntityRows := [][]feast.Row{}
+	for _, entity := range configEntities {
+		vals, err := getValuesFromJSONPayload(request, entity)
+		if err != nil {
+			return nil, fmt.Errorf("unable to extract entity %s: %v", entity.Name, err)
+		}
+
+		rows := []feast.Row{}
+		for _, val := range vals {
+			rows = append(rows, feast.Row{
+				entity.Name: val,
+			})
+		}
+		allEntityRows = append(allEntityRows, rows)
+	}
+
+	if len(allEntityRows) == 0 {
+		return nil, fmt.Errorf("no entity extracted")
+	}
+
+	entities := allEntityRows[0]
+
+	entityIndex := 1
+	for entityIndex < len(configEntities) {
+		rows := allEntityRows[entityIndex]
+
+		newEntities := []feast.Row{}
+		for _, entity := range entities {
+			for _, row := range rows {
+				newFeastRow := feast.Row{}
+				for key, value := range entity {
+					newFeastRow[key] = value
+				}
+				newFeastRow[configEntities[entityIndex].Name] = row[configEntities[entityIndex].Name]
+				newEntities = append(newEntities, newFeastRow)
+			}
+		}
+		entities = newEntities
+
+		entityIndex++
+	}
+
+	return entities, nil
+}
 func getFloatValue(val interface{}) (float64, error) {
 	switch i := val.(type) {
 	case float64:

--- a/api/pkg/transformer/feast/transformer.go
+++ b/api/pkg/transformer/feast/transformer.go
@@ -249,6 +249,7 @@ func buildEntitiesRequest(request []byte, configEntities []*transformer.Entity) 
 
 	entityIndex := 1
 	for entityIndex < len(configEntities) {
+		entityName := configEntities[entityIndex].Name
 		rows := allEntityRows[entityIndex]
 
 		newEntities := []feast.Row{}
@@ -258,7 +259,8 @@ func buildEntitiesRequest(request []byte, configEntities []*transformer.Entity) 
 				for key, value := range entity {
 					newFeastRow[key] = value
 				}
-				newFeastRow[configEntities[entityIndex].Name] = row[configEntities[entityIndex].Name]
+
+				newFeastRow[entityName] = row[entityName]
 				newEntities = append(newEntities, newFeastRow)
 			}
 		}

--- a/api/pkg/transformer/feast/transformer_test.go
+++ b/api/pkg/transformer/feast/transformer_test.go
@@ -685,6 +685,52 @@ func Test_buildEntitiesRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "3 entities with 1 value each except one",
+			args: args{
+				request: []byte(`{"customer_id":1111,"merchant_id":"M111","driver_id":["D111","D222","D333","D444"]}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id",
+					},
+					{
+						Name:      "driver_id",
+						ValueType: "STRING",
+						JsonPath:  "$.driver_id[*]",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D111"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D222"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D333"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D444"),
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "3 entities with multiple value each except one",
 			args: args{
 				request: []byte(`{"customer_id":1111,"merchant_id":["M111","M222"],"driver_id":["D111","D222"]}`),

--- a/api/pkg/transformer/feast/transformer_test.go
+++ b/api/pkg/transformer/feast/transformer_test.go
@@ -555,7 +555,36 @@ func Test_buildEntitiesRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "2 entities with one of them has 2 values",
+			name: "2 entities with the fisrt one has 2 values",
+			args: args{
+				request: []byte(`{"customer_id":[1111,2222],"merchant_id":"M111"}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id[*]",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+				},
+				{
+					"customer_id": feast.Int64Val(2222),
+					"merchant_id": feast.StrVal("M111"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "2 entities with the second one has 2 values",
 			args: args{
 				request: []byte(`{"customer_id":1111,"merchant_id":["M111","M222"]}`),
 				configEntities: []*transformer.Entity{
@@ -731,7 +760,7 @@ func Test_buildEntitiesRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "3 entities with multiple value each except one",
+			name: "3 entities with multiple value each except the first one",
 			args: args{
 				request: []byte(`{"customer_id":1111,"merchant_id":["M111","M222"],"driver_id":["D111","D222"]}`),
 				configEntities: []*transformer.Entity{
@@ -772,6 +801,47 @@ func Test_buildEntitiesRequest(t *testing.T) {
 					"customer_id": feast.Int64Val(1111),
 					"merchant_id": feast.StrVal("M222"),
 					"driver_id":   feast.StrVal("D222"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "3 entities with the first one has multiple values",
+			args: args{
+				request: []byte(`{"customer_id":[1111,2222,3333],"merchant_id":"M111","driver_id":"D111"}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id[*]",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id",
+					},
+					{
+						Name:      "driver_id",
+						ValueType: "STRING",
+						JsonPath:  "$.driver_id",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D111"),
+				},
+				{
+					"customer_id": feast.Int64Val(2222),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D111"),
+				},
+				{
+					"customer_id": feast.Int64Val(3333),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D111"),
 				},
 			},
 			wantErr: false,
@@ -839,6 +909,61 @@ func Test_buildEntitiesRequest(t *testing.T) {
 					"merchant_id": feast.StrVal("M222"),
 					"driver_id":   feast.StrVal("D222"),
 				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "4 entities with multiple values each",
+			args: args{
+				request: []byte(`{"customer_id":[1111,2222,3333],"merchant_id":["M111","M222"],"driver_id":["D111","D222"],"order_id":["O111","O222"]}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id[*]",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id[*]",
+					},
+					{
+						Name:      "driver_id",
+						ValueType: "STRING",
+						JsonPath:  "$.driver_id[*]",
+					},
+					{
+						Name:      "order_id",
+						ValueType: "STRING",
+						JsonPath:  "$.order_id[*]",
+					},
+				},
+			},
+			want: []feast.Row{
+				{"customer_id": feast.Int64Val(1111), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(1111), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(1111), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(1111), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(1111), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(1111), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(1111), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(1111), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(2222), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(2222), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(2222), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(2222), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(2222), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(2222), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(2222), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(2222), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(3333), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(3333), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(3333), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(3333), "merchant_id": feast.StrVal("M111"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(3333), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(3333), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D111"), "order_id": feast.StrVal("O222")},
+				{"customer_id": feast.Int64Val(3333), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O111")},
+				{"customer_id": feast.Int64Val(3333), "merchant_id": feast.StrVal("M222"), "driver_id": feast.StrVal("D222"), "order_id": feast.StrVal("O222")},
 			},
 			wantErr: false,
 		},

--- a/api/pkg/transformer/feast/transformer_test.go
+++ b/api/pkg/transformer/feast/transformer_test.go
@@ -2,17 +2,17 @@ package feast
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 
 	feast "github.com/feast-dev/feast/sdk/go"
 	"github.com/feast-dev/feast/sdk/go/protos/feast/serving"
 	"github.com/feast-dev/feast/sdk/go/protos/feast/types"
-	"github.com/stretchr/testify/mock"
-	"go.uber.org/zap"
-
 	"github.com/gojek/merlin/pkg/transformer"
 	"github.com/gojek/merlin/pkg/transformer/feast/mocks"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 )
 
 func TestTransformer_Transform(t *testing.T) {
@@ -47,6 +47,7 @@ func TestTransformer_Transform(t *testing.T) {
 							{
 								Project: "default",
 								Entities: []*transformer.Entity{
+
 									{
 										Name:      "driver_id",
 										ValueType: "STRING",
@@ -472,6 +473,342 @@ func TestTransformer_Transform(t *testing.T) {
 			}
 
 			mockFeast.AssertExpectations(t)
+		})
+	}
+}
+
+func Test_buildEntitiesRequest(t *testing.T) {
+	type args struct {
+		request        []byte
+		configEntities []*transformer.Entity
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []feast.Row
+		wantErr bool
+	}{
+		{
+			name: "1 entity",
+			args: args{
+				request: []byte(`{"customer_id":1111}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "1 entity with multiple values",
+			args: args{
+				request: []byte(`{"customer_id":[1111,2222]}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id[*]",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+				},
+				{
+					"customer_id": feast.Int64Val(2222),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "2 entities with 1 value each",
+			args: args{
+				request: []byte(`{"customer_id":1111,"merchant_id":"M111"}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "2 entities with one of them has 2 values",
+			args: args{
+				request: []byte(`{"customer_id":1111,"merchant_id":["M111","M222"]}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id[*]",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M222"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "2 entities with one of them has 3 values",
+			args: args{
+				request: []byte(`{"customer_id":1111,"merchant_id":["M111","M222","M333"]}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id[*]",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M222"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M333"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "2 entities with multiple values each",
+			args: args{
+				request: []byte(`{"customer_id":[1111,2222],"merchant_id":["M111","M222"]}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id[*]",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id[*]",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M222"),
+				},
+				{
+					"customer_id": feast.Int64Val(2222),
+					"merchant_id": feast.StrVal("M111"),
+				},
+				{
+					"customer_id": feast.Int64Val(2222),
+					"merchant_id": feast.StrVal("M222"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "3 entities with 1 value each",
+			args: args{
+				request: []byte(`{"customer_id":1111,"merchant_id":"M111","driver_id":"D111"}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id",
+					},
+					{
+						Name:      "driver_id",
+						ValueType: "STRING",
+						JsonPath:  "$.driver_id",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D111"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "3 entities with multiple value each except one",
+			args: args{
+				request: []byte(`{"customer_id":1111,"merchant_id":["M111","M222"],"driver_id":["D111","D222"]}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id[*]",
+					},
+					{
+						Name:      "driver_id",
+						ValueType: "STRING",
+						JsonPath:  "$.driver_id[*]",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D111"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D222"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M222"),
+					"driver_id":   feast.StrVal("D111"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M222"),
+					"driver_id":   feast.StrVal("D222"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "3 entities with multiple values each",
+			args: args{
+				request: []byte(`{"customer_id":[1111,2222],"merchant_id":["M111","M222"],"driver_id":["D111","D222"]}`),
+				configEntities: []*transformer.Entity{
+					{
+						Name:      "customer_id",
+						ValueType: "INT64",
+						JsonPath:  "$.customer_id[*]",
+					},
+					{
+						Name:      "merchant_id",
+						ValueType: "STRING",
+						JsonPath:  "$.merchant_id[*]",
+					},
+					{
+						Name:      "driver_id",
+						ValueType: "STRING",
+						JsonPath:  "$.driver_id[*]",
+					},
+				},
+			},
+			want: []feast.Row{
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D111"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D222"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M222"),
+					"driver_id":   feast.StrVal("D111"),
+				},
+				{
+					"customer_id": feast.Int64Val(1111),
+					"merchant_id": feast.StrVal("M222"),
+					"driver_id":   feast.StrVal("D222"),
+				},
+				{
+					"customer_id": feast.Int64Val(2222),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D111"),
+				},
+				{
+					"customer_id": feast.Int64Val(2222),
+					"merchant_id": feast.StrVal("M111"),
+					"driver_id":   feast.StrVal("D222"),
+				},
+				{
+					"customer_id": feast.Int64Val(2222),
+					"merchant_id": feast.StrVal("M222"),
+					"driver_id":   feast.StrVal("D111"),
+				},
+				{
+					"customer_id": feast.Int64Val(2222),
+					"merchant_id": feast.StrVal("M222"),
+					"driver_id":   feast.StrVal("D222"),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildEntitiesRequest(tt.args.request, tt.args.configEntities)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildEntitiesRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			gotJSON, _ := json.Marshal(got)
+			wantJSON, _ := json.Marshal(tt.want)
+			if !reflect.DeepEqual(gotJSON, wantJSON) {
+				t.Errorf("buildEntitiesRequest() =\n%v\nwant\n%v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

The current implementation of the standard transformer cannot retrieve features for multiple entities at once due to an invalid FeastRequest schema.

For given entities config in transformer config:
```yaml
entities:
  - name: merchant_uuid
    valueType: STRING
    jsonPath: $.merchants[*].id
  - name: customer_id
    valueType: INT64
    jsonPath: $.customer_id
```

It will create this request:
```
"Entities": [
    {
      "customer_id": {
        "Val": {
          "Int64Val": 1111
        }
      }
    },
    {
      "merchant_uuid": {
        "Val": {
          "StringVal": "M111"
        }
      }
    }
  ],
```

This PR fixes this so the request will be like this:
```
"Entities": [
    {
      "customer_id": {
        "Val": {
          "Int64Val": 1111
        }
      },
      "merchant_uuid": {
        "Val": {
          "StringVal": "M111"
        }
      }
    }
  ],
```

Note that merchant_uuid is sibling of customer_id field instead of entire different feast row.

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally