### PR TITLE
Optimize entity extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,11 @@ it-test-api-ci:
 	@cd ${API_PATH} && go test -race -short -cover -coverprofile cover.out -tags unit,integration ${API_ALL_PACKAGES}
 	@cd ${API_PATH} && go tool cover -func cover.out
 
+.PHONY:
+bench:
+	@echo "> Running Benchmark ..."
+	@cd ${API_PATH} && go test ${API_ALL_PACKAGES} -bench=. -run=^$$
+
 # ============================================================
 # Building recipes
 # ============================================================

--- a/api/cmd/transformer/main.go
+++ b/api/cmd/transformer/main.go
@@ -74,7 +74,10 @@ func main() {
 		logger.Fatal("Unable to initialize Feast client", zap.Error(err))
 	}
 
-	f := feast.NewTransformer(feastClient, config, &cfg.Feast, logger)
+	f, err := feast.NewTransformer(feastClient, config, &cfg.Feast, logger)
+	if err != nil {
+		logger.Fatal("Unable to initialize transformer", zap.Error(err))
+	}
 
 	s := server.New(&cfg.Server, logger)
 	s.PreprocessHandler = f.Transform

--- a/api/go.mod
+++ b/api/go.mod
@@ -55,6 +55,7 @@ require (
 	k8s.io/apimachinery v0.18.3
 	k8s.io/client-go v0.18.3
 	knative.dev/pkg v0.0.0-20191217184203-cf220a867b3d
+	sigs.k8s.io/controller-runtime v0.4.0
 )
 
 replace (

--- a/api/go.sum
+++ b/api/go.sum
@@ -714,6 +714,7 @@ github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kubeflow/kfserving v0.4.1 h1:CDsCqkIK6QVhGA6e9dWInIDpso68XhKEuXGI5+j8GoA=
 github.com/kubeflow/kfserving v0.4.1/go.mod h1:yGPsc6vK4+V1I8Gtz4Fax/Oc85+6U6T9W+BNWyu6XxA=
@@ -821,6 +822,7 @@ github.com/neo4j-drivers/gobolt v1.7.4/go.mod h1:O9AUbip4Dgre+CD3p40dnMD4a4r52QB
 github.com/neo4j/neo4j-go-driver v1.7.4/go.mod h1:aPO0vVr+WnhEJne+FgFjfsjzAnssPFLucHgGZ76Zb/U=
 github.com/newrelic/go-agent v2.13.0+incompatible h1:Dl6m75MHAzfB0kicv9GiLxzQatRjTLUAdrnYyoT8s4M=
 github.com/newrelic/go-agent v2.13.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -854,6 +856,7 @@ github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opentracing-contrib/go-grpc v0.0.0-20200813121455-4a6760c71486 h1:K35HCWaOTJIPW6cDHK4yj3QfRY/NhE0pBbfoc0M2NMQ=
 github.com/opentracing-contrib/go-grpc v0.0.0-20200813121455-4a6760c71486/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
+github.com/opentracing-contrib/go-stdlib v1.0.0 h1:TBS7YuVotp8myLon4Pv7BtCBzOTo1DeZCld0Z63mW2w=
 github.com/opentracing-contrib/go-stdlib v1.0.0/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -1001,6 +1004,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20160928074757-e7cb7fa329f4/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/goleveldb v0.0.0-20181127023241-353a9fca669c/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
@@ -1017,6 +1021,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/uber-go/atomic v1.4.0/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/uber/jaeger-client-go v2.16.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-client-go v2.25.0+incompatible h1:IxcNZ7WRY1Y3G4poYlx24szfsn/3LvK9QHCq9oQw8+U=
 github.com/uber/jaeger-client-go v2.25.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.0.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/jaeger-lib v2.4.0+incompatible h1:fY7QsGQWiCt8pajv4r7JEvmATdCVaWxXbjwyYwsNaLQ=
@@ -1383,6 +1388,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
@@ -1504,6 +1510,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
@@ -1538,6 +1545,7 @@ gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=

--- a/api/pkg/transformer/feast/entity_extractor.go
+++ b/api/pkg/transformer/feast/entity_extractor.go
@@ -1,7 +1,6 @@
 package feast
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -12,16 +11,10 @@ import (
 	"github.com/gojek/merlin/pkg/transformer"
 )
 
-func getValuesFromJSONPayload(body []byte, entity *transformer.Entity) ([]*feastType.Value, error) {
+func getValuesFromJSONPayload(nodesBody interface{}, entity *transformer.Entity, compiledJsonPath *jsonpath.Compiled) ([]*feastType.Value, error) {
 	feastValType := feastType.ValueType_Enum(feastType.ValueType_Enum_value[entity.ValueType])
 
-	var nodesBody interface{}
-	err := json.Unmarshal(body, &nodesBody)
-	if err != nil {
-		return nil, err
-	}
-
-	o, err := jsonpath.JsonPathLookup(nodesBody, entity.JsonPath)
+	o, err := compiledJsonPath.Lookup(nodesBody)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/transformer/feast/entity_extractor_test.go
+++ b/api/pkg/transformer/feast/entity_extractor_test.go
@@ -1,11 +1,13 @@
 package feast
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
 	feast "github.com/feast-dev/feast/sdk/go"
 	feastType "github.com/feast-dev/feast/sdk/go/protos/feast/types"
+	"github.com/oliveagle/jsonpath"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/gojek/merlin/pkg/transformer"
@@ -287,8 +289,12 @@ func TestGetValuesFromJSONPayload(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			c, _ := jsonpath.Compile(test.entityConfig.JsonPath)
 
-			actual, err := getValuesFromJSONPayload(testData, test.entityConfig)
+			var nodesBody interface{}
+			json.Unmarshal(testData, &nodesBody)
+
+			actual, err := getValuesFromJSONPayload(nodesBody, test.entityConfig, c)
 			if err != nil {
 				if test.expError != nil {
 					assert.EqualError(t, err, test.expError.Error())
@@ -303,354 +309,377 @@ func TestGetValuesFromJSONPayload(t *testing.T) {
 }
 
 func BenchmarkGetValuesFromJSONPayload100Entity(b *testing.B) {
+	entityConfig := &transformer.Entity{
+		Name:      "",
+		ValueType: "INT32",
+		JsonPath:  "$.array[*].id",
+	}
+	c, _ := jsonpath.Compile(entityConfig.JsonPath)
+	var nodesBody interface{}
+	json.Unmarshal(benchData, &nodesBody)
+
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		Result, _ = getValuesFromJSONPayload(benchData, &transformer.Entity{
-			Name:      "",
-			ValueType: "INT32",
-			JsonPath:  "$.array[*].id",
-		})
+		Result, _ = getValuesFromJSONPayload(nodesBody, entityConfig, c)
 	}
 }
 
 func BenchmarkGetValuesFromJSONPayload1StringEntity(b *testing.B) {
 	b.ReportAllocs()
+	entityConfig := &transformer.Entity{
+		Name:      "",
+		ValueType: "STRING",
+		JsonPath:  "$.string",
+	}
+	c, _ := jsonpath.Compile(entityConfig.JsonPath)
+	var nodesBody interface{}
+	json.Unmarshal(benchData, &nodesBody)
+
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		Result, _ = getValuesFromJSONPayload(benchData, &transformer.Entity{
-			Name:      "",
-			ValueType: "STRING",
-			JsonPath:  "$.string",
-		})
+		Result, _ = getValuesFromJSONPayload(nodesBody, entityConfig, c)
 	}
 }
 
 func BenchmarkGetValuesFromJSONPayload1IntegerEntity(b *testing.B) {
 	b.ReportAllocs()
+	entityConfig := &transformer.Entity{
+		Name:      "",
+		ValueType: "INT32",
+		JsonPath:  "$.integer",
+	}
+	c, _ := jsonpath.Compile(entityConfig.JsonPath)
+	var nodesBody interface{}
+	json.Unmarshal(benchData, &nodesBody)
+
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		Result, _ = getValuesFromJSONPayload(benchData, &transformer.Entity{
-			Name:      "",
-			ValueType: "INT32",
-			JsonPath:  "$.integer",
-		})
+		Result, _ = getValuesFromJSONPayload(nodesBody, entityConfig, c)
 	}
 }
 
 func BenchmarkGetValuesFromJSONPayload1FloatEntity(b *testing.B) {
 	b.ReportAllocs()
+	entityConfig := &transformer.Entity{
+		Name:      "",
+		ValueType: "DOUBLE",
+		JsonPath:  "$.float",
+	}
+	c, _ := jsonpath.Compile(entityConfig.JsonPath)
+	var nodesBody interface{}
+	json.Unmarshal(benchData, &nodesBody)
+
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		Result, _ = getValuesFromJSONPayload(benchData, &transformer.Entity{
-			Name:      "",
-			ValueType: "DOUBLE",
-			JsonPath:  "$.float",
-		})
+		Result, _ = getValuesFromJSONPayload(nodesBody, entityConfig, c)
 	}
 }
 
 var Result []*feastType.Value
 var benchData = []byte(`{
-  "string": "string_value",
-  "integer" : 1234,
-  "float" : 1234.111,
-  "array": [
-    {
-      "id": 0
-    },
-    {
-      "id": 1
-    },
-    {
-      "id": 2
-    },
-    {
-      "id": 3
-    },
-    {
-      "id": 4
-    },
-    {
-      "id": 5
-    },
-    {
-      "id": 6
-    },
-    {
-      "id": 7
-    },
-    {
-      "id": 8
-    },
-    {
-      "id": 9
-    },
-    {
-      "id": 10
-    },
-    {
-      "id": 11
-    },
-    {
-      "id": 12
-    },
-    {
-      "id": 13
-    },
-    {
-      "id": 14
-    },
-    {
-      "id": 15
-    },
-    {
-      "id": 16
-    },
-    {
-      "id": 17
-    },
-    {
-      "id": 18
-    },
-    {
-      "id": 19
-    },
-    {
-      "id": 20
-    },
-    {
-      "id": 21
-    },
-    {
-      "id": 22
-    },
-    {
-      "id": 23
-    },
-    {
-      "id": 24
-    },
-    {
-      "id": 25
-    },
-    {
-      "id": 26
-    },
-    {
-      "id": 27
-    },
-    {
-      "id": 28
-    },
-    {
-      "id": 29
-    },
-    {
-      "id": 30
-    },
-    {
-      "id": 31
-    },
-    {
-      "id": 32
-    },
-    {
-      "id": 33
-    },
-    {
-      "id": 34
-    },
-    {
-      "id": 35
-    },
-    {
-      "id": 36
-    },
-    {
-      "id": 37
-    },
-    {
-      "id": 38
-    },
-    {
-      "id": 39
-    },
-    {
-      "id": 40
-    },
-    {
-      "id": 41
-    },
-    {
-      "id": 42
-    },
-    {
-      "id": 43
-    },
-    {
-      "id": 44
-    },
-    {
-      "id": 45
-    },
-    {
-      "id": 46
-    },
-    {
-      "id": 47
-    },
-    {
-      "id": 48
-    },
-    {
-      "id": 49
-    },
-    {
-      "id": 50
-    },
-    {
-      "id": 51
-    },
-    {
-      "id": 52
-    },
-    {
-      "id": 53
-    },
-    {
-      "id": 54
-    },
-    {
-      "id": 55
-    },
-    {
-      "id": 56
-    },
-    {
-      "id": 57
-    },
-    {
-      "id": 58
-    },
-    {
-      "id": 59
-    },
-    {
-      "id": 60
-    },
-    {
-      "id": 61
-    },
-    {
-      "id": 62
-    },
-    {
-      "id": 63
-    },
-    {
-      "id": 64
-    },
-    {
-      "id": 65
-    },
-    {
-      "id": 66
-    },
-    {
-      "id": 67
-    },
-    {
-      "id": 68
-    },
-    {
-      "id": 69
-    },
-    {
-      "id": 70
-    },
-    {
-      "id": 71
-    },
-    {
-      "id": 72
-    },
-    {
-      "id": 73
-    },
-    {
-      "id": 74
-    },
-    {
-      "id": 75
-    },
-    {
-      "id": 76
-    },
-    {
-      "id": 77
-    },
-    {
-      "id": 78
-    },
-    {
-      "id": 79
-    },
-    {
-      "id": 80
-    },
-    {
-      "id": 81
-    },
-    {
-      "id": 82
-    },
-    {
-      "id": 83
-    },
-    {
-      "id": 84
-    },
-    {
-      "id": 85
-    },
-    {
-      "id": 86
-    },
-    {
-      "id": 87
-    },
-    {
-      "id": 88
-    },
-    {
-      "id": 89
-    },
-    {
-      "id": 90
-    },
-    {
-      "id": 91
-    },
-    {
-      "id": 92
-    },
-    {
-      "id": 93
-    },
-    {
-      "id": 94
-    },
-    {
-      "id": 95
-    },
-    {
-      "id": 96
-    },
-    {
-      "id": 97
-    },
-    {
-      "id": 98
-    },
-    {
-      "id": 99
-    }
-  ]
+ "string": "string_value",
+ "integer" : 1234,
+ "float" : 1234.111,
+ "array": [
+   {
+     "id": 0
+   },
+   {
+     "id": 1
+   },
+   {
+     "id": 2
+   },
+   {
+     "id": 3
+   },
+   {
+     "id": 4
+   },
+   {
+     "id": 5
+   },
+   {
+     "id": 6
+   },
+   {
+     "id": 7
+   },
+   {
+     "id": 8
+   },
+   {
+     "id": 9
+   },
+   {
+     "id": 10
+   },
+   {
+     "id": 11
+   },
+   {
+     "id": 12
+   },
+   {
+     "id": 13
+   },
+   {
+     "id": 14
+   },
+   {
+     "id": 15
+   },
+   {
+     "id": 16
+   },
+   {
+     "id": 17
+   },
+   {
+     "id": 18
+   },
+   {
+     "id": 19
+   },
+   {
+     "id": 20
+   },
+   {
+     "id": 21
+   },
+   {
+     "id": 22
+   },
+   {
+     "id": 23
+   },
+   {
+     "id": 24
+   },
+   {
+     "id": 25
+   },
+   {
+     "id": 26
+   },
+   {
+     "id": 27
+   },
+   {
+     "id": 28
+   },
+   {
+     "id": 29
+   },
+   {
+     "id": 30
+   },
+   {
+     "id": 31
+   },
+   {
+     "id": 32
+   },
+   {
+     "id": 33
+   },
+   {
+     "id": 34
+   },
+   {
+     "id": 35
+   },
+   {
+     "id": 36
+   },
+   {
+     "id": 37
+   },
+   {
+     "id": 38
+   },
+   {
+     "id": 39
+   },
+   {
+     "id": 40
+   },
+   {
+     "id": 41
+   },
+   {
+     "id": 42
+   },
+   {
+     "id": 43
+   },
+   {
+     "id": 44
+   },
+   {
+     "id": 45
+   },
+   {
+     "id": 46
+   },
+   {
+     "id": 47
+   },
+   {
+     "id": 48
+   },
+   {
+     "id": 49
+   },
+   {
+     "id": 50
+   },
+   {
+     "id": 51
+   },
+   {
+     "id": 52
+   },
+   {
+     "id": 53
+   },
+   {
+     "id": 54
+   },
+   {
+     "id": 55
+   },
+   {
+     "id": 56
+   },
+   {
+     "id": 57
+   },
+   {
+     "id": 58
+   },
+   {
+     "id": 59
+   },
+   {
+     "id": 60
+   },
+   {
+     "id": 61
+   },
+   {
+     "id": 62
+   },
+   {
+     "id": 63
+   },
+   {
+     "id": 64
+   },
+   {
+     "id": 65
+   },
+   {
+     "id": 66
+   },
+   {
+     "id": 67
+   },
+   {
+     "id": 68
+   },
+   {
+     "id": 69
+   },
+   {
+     "id": 70
+   },
+   {
+     "id": 71
+   },
+   {
+     "id": 72
+   },
+   {
+     "id": 73
+   },
+   {
+     "id": 74
+   },
+   {
+     "id": 75
+   },
+   {
+     "id": 76
+   },
+   {
+     "id": 77
+   },
+   {
+     "id": 78
+   },
+   {
+     "id": 79
+   },
+   {
+     "id": 80
+   },
+   {
+     "id": 81
+   },
+   {
+     "id": 82
+   },
+   {
+     "id": 83
+   },
+   {
+     "id": 84
+   },
+   {
+     "id": 85
+   },
+   {
+     "id": 86
+   },
+   {
+     "id": 87
+   },
+   {
+     "id": 88
+   },
+   {
+     "id": 89
+   },
+   {
+     "id": 90
+   },
+   {
+     "id": 91
+   },
+   {
+     "id": 92
+   },
+   {
+     "id": 93
+   },
+   {
+     "id": 94
+   },
+   {
+     "id": 95
+   },
+   {
+     "id": 96
+   },
+   {
+     "id": 97
+   },
+   {
+     "id": 98
+   },
+   {
+     "id": 99
+   }
+ ]
 }`)

--- a/api/pkg/transformer/feast/transformer.go
+++ b/api/pkg/transformer/feast/transformer.go
@@ -197,7 +197,7 @@ func buildEntitiesRequest(ctx context.Context, request []byte, configEntities []
 			return nil, fmt.Errorf("unable to compile jsonpath for entity %s: %s", configEntity.Name, configEntity.JsonPath)
 		}
 
-		vals, err := getValuesFromJSONPayload(request, configEntity, c)
+		vals, err := getValuesFromJSONPayload(nodesBody, configEntity, c)
 		if err != nil {
 			return nil, fmt.Errorf("unable to extract entity %s: %v", configEntity.Name, err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
The PR contain optimization in merlin standard transformer:
1. Reduce number of call to json marshall
2. Reuse compiled json path

The benchmark result:

Before changes:
```
BenchmarkGetValuesFromJSONPayload100Entity-12              19004             62919 ns/op           53320 B/op        750 allocs/op
BenchmarkGetValuesFromJSONPayload1StringEntity-12          24273             49517 ns/op           40288 B/op        529 allocs/op
BenchmarkGetValuesFromJSONPayload1IntegerEntity-12         24187             49356 ns/op           40248 B/op        529 allocs/op
BenchmarkGetValuesFromJSONPayload1FloatEntity-12           24324             49215 ns/op           40232 B/op        527 allocs/op
```

After:
```
BenchmarkGetValuesFromJSONPayload100Entity-12              85334             12726 ns/op           12992 B/op        219 allocs/op
BenchmarkGetValuesFromJSONPayload1StringEntity-12        5982757               201 ns/op             104 B/op          4 allocs/op
BenchmarkGetValuesFromJSONPayload1IntegerEntity-12      10752278               113 ns/op              76 B/op          3 allocs/op
BenchmarkGetValuesFromJSONPayload1FloatEntity-12         9881186               121 ns/op              80 B/op          3 allocs/op
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE
```release-note

```

**Checklist**

- ~~[ ] Added unit test, integration, and/or e2e tests~~
- [x] Tested locally
- ~~[ ] Updated documentation~~
- ~~[ ] Update Swagger spec if the PR introduce API changes~~
- ~~[ ] Regenerated Golang and Python client if the PR introduce API changes~~
