### PR TITLE
Enable retry in create prediction job

### DIFF
--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1130,9 +1130,9 @@ class ModelVersion:
                               title=f"Running prediction job {j.id} from model {self.model.name} version {self.id} "
                                     f"under project {self.model.project.name}")
         retry = DEFAULT_API_CALL_RETRY
-        while (j.status == "pending" or \
+        while j.status == "pending" or \
                 j.status == "running" or \
-                j.status == "terminating") and retry > 0:
+                j.status == "terminating":
             if not sync:
                 j = job_client.models_model_id_versions_version_id_jobs_job_id_get(model_id=self.model.id,
                                                                                    version_id=self.id,
@@ -1146,9 +1146,11 @@ class ModelVersion:
                     retry = DEFAULT_API_CALL_RETRY
                 except Exception:
                         retry -= 1
+                        if retry == 0:
+                            j.status = "failed"
+                            break
             bar.update()
             sleep(5)
-
         bar.stop()
 
         if j.status == "failed" or j.status == "failed_submission":

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1128,20 +1128,27 @@ class ModelVersion:
         bar = pyprind.ProgBar(100, track_time=True,
                               title=f"Running prediction job {j.id} from model {self.model.name} version {self.id} "
                                     f"under project {self.model.project.name}")
+        retry = 5
         while j.status == "pending" or \
                 j.status == "running" or \
-                j.status == "terminating":
+                j.status == "terminating" or \
+                retry > 0:
             if not sync:
                 j = job_client.models_model_id_versions_version_id_jobs_job_id_get(model_id=self.model.id,
                                                                                    version_id=self.id,
                                                                                    job_id=j.id)
                 return PredictionJob(j, self._api_client)
             else:
-                j = job_client.models_model_id_versions_version_id_jobs_job_id_get(model_id=self.model.id,
-                                                                                   version_id=self.id,
-                                                                                   job_id=j.id)
+                try:
+                  j = job_client.models_model_id_versions_version_id_jobs_job_id_get(model_id=self.model.id,
+                                                                                       version_id=self.id,
+                                                                                       job_id=j.id)
+                except Exception:
+                    retry -= 1
+                    sleep(10)
             bar.update()
             sleep(5)
+
         bar.stop()
 
         if j.status == "failed" or j.status == "failed_submission":

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -51,6 +51,8 @@ from merlin.version import VERSION
 DEFAULT_MODEL_PATH = "model"
 DEFAULT_MODEL_VERSION_LIMIT = 50
 DEFAULT_API_CALL_RETRY = 5
+DEFAULT_PREDICTION_JOB_DELAY = 5
+DEFAULT_PREDICTION_JOB_RETRY_DELAY = 30
 V1 = "v1"
 PREDICTION_JOB = "PredictionJob"
 
@@ -1149,8 +1151,9 @@ class ModelVersion:
                         if retry == 0:
                             j.status = "failed"
                             break
+                        sleep(DEFAULT_PREDICTION_JOB_RETRY_DELAY)
             bar.update()
-            sleep(5)
+            sleep(DEFAULT_PREDICTION_JOB_DELAY)
         bar.stop()
 
         if j.status == "failed" or j.status == "failed_submission":

--- a/python/sdk/test/model_test.py
+++ b/python/sdk/test/model_test.py
@@ -382,7 +382,7 @@ class TestModelVersion:
         assert actual_req["config"]["service_account_name"] == "my-service-account"
 
     @responses.activate
-    def test_create_sync_prediction_job_failed(self, version):
+    def test_create_prediction_job_with_retry_failed(self, version):
         job_1.status = "pending"
         responses.add("POST", '/v1/models/1/versions/1/jobs',
                       body=json.dumps(job_1.to_dict()),
@@ -443,25 +443,11 @@ class TestModelVersion:
                         return match
         responses._find_match = types.MethodType(_find_match_patched, responses)
 
-        responses.add("GET", '/v1/models/1/versions/1/jobs/1',
-                      body=json.dumps(job_1.to_dict()),
-                      status=500,
-                      content_type='application/json')
-
-        responses.add("GET", '/v1/models/1/versions/1/jobs/1',
-                      body=json.dumps(job_1.to_dict()),
-                      status=500,
-                      content_type='application/json')
-
-        responses.add("GET", '/v1/models/1/versions/1/jobs/1',
-                      body=json.dumps(job_1.to_dict()),
-                      status=500,
-                      content_type='application/json')
-
-        responses.add("GET", '/v1/models/1/versions/1/jobs/1',
-                      body=json.dumps(job_1.to_dict()),
-                      status=500,
-                      content_type='application/json')
+        for i in range(4):
+            responses.add("GET", '/v1/models/1/versions/1/jobs/1',
+                          body=json.dumps(job_1.to_dict()),
+                          status=500,
+                          content_type='application/json')
 
         job_1.status = "completed"
         responses.add("GET", '/v1/models/1/versions/1/jobs/1',
@@ -497,6 +483,75 @@ class TestModelVersion:
         assert actual_req["config"]["job_config"]["model"]["uri"] == f"{version.artifact_uri}/model"
         assert actual_req["config"]["job_config"]["model"]["type"] == ModelType.PYFUNC_V2.value.upper()
         assert actual_req["config"]["service_account_name"] == "my-service-account"
+
+        # unpatch
+        responses._find_match = types.MethodType(_find_match, responses)
+
+    @responses.activate
+    def test_create_prediction_job_with_retry_pending_then_failed(self, version):
+        job_1.status = "pending"
+        responses.add("POST", '/v1/models/1/versions/1/jobs',
+                      body=json.dumps(job_1.to_dict()),
+                      status=200,
+                      content_type='application/json')
+
+        # Patch the method as currently it is not supported in the library itself
+        # I am going this way because this is a test, should be safe
+        # https://github.com/getsentry/responses/issues/135
+        def _find_match(self, request):
+            for match in self._urls:
+                if request.method == match['method'] and \
+                        self._has_url_match(match, request.url):
+                    return match
+
+        def _find_match_patched(self, request):
+            for index, match in enumerate(self._urls):
+                if request.method == match['method'] and \
+                        self._has_url_match(match, request.url):
+                    if request.method == "GET" and request.url == "/v1/models/1/versions/1/jobs/1":
+                        return self._urls.pop(index)
+                    else:
+                        return match
+        responses._find_match = types.MethodType(_find_match_patched, responses)
+
+        for i in range(3):
+            responses.add("GET", '/v1/models/1/versions/1/jobs/1',
+                          body=json.dumps(job_1.to_dict()),
+                          status=500,
+                          content_type='application/json')
+
+        responses.add("GET", '/v1/models/1/versions/1/jobs/1',
+                      body=json.dumps(job_1.to_dict()),
+                      status=200,
+                      content_type='application/json')
+
+        job_1.status = "failed"
+        for i in range(5):
+            responses.add("GET", '/v1/models/1/versions/1/jobs/1',
+                          body=json.dumps(job_1.to_dict()),
+                          status=500,
+                          content_type='application/json')
+
+        bq_src = BigQuerySource(table="project.dataset.source_table",
+                                features=["feature_1", "feature2"],
+                                options={"key": "val"})
+
+        bq_sink = BigQuerySink(table="project.dataset.result_table",
+                               result_column="prediction",
+                               save_mode=SaveMode.OVERWRITE,
+                               staging_bucket="gs://test",
+                               options={"key": "val"})
+
+        job_config = PredictionJobConfig(source=bq_src,
+                                         sink=bq_sink,
+                                         service_account_name="my-service-account",
+                                         result_type=ResultType.INTEGER)
+
+        with pytest.raises(ValueError):
+            j = version.create_prediction_job(job_config=job_config)
+            assert j.id == job_1.id
+            assert j.error == job_1.error
+            assert j.name == job_1.name
 
         # unpatch
         responses._find_match = types.MethodType(_find_match, responses)

--- a/python/sdk/test/model_test.py
+++ b/python/sdk/test/model_test.py
@@ -17,6 +17,7 @@ import types
 import pytest
 from merlin.model import ModelType
 from urllib3_mock import Responses
+from unittest.mock import patch
 
 import client as cl
 from merlin.batch.config import PredictionJobConfig, ResultType
@@ -173,7 +174,6 @@ class TestProject:
 
         secret_names = project.list_secret()
         assert secret_names == [self.secret_1.name, self.secret_2.name]
-
 
 class TestModelVersion:
     @responses.activate
@@ -381,6 +381,8 @@ class TestModelVersion:
         assert actual_req["config"]["job_config"]["model"]["type"] == ModelType.PYFUNC_V2.value.upper()
         assert actual_req["config"]["service_account_name"] == "my-service-account"
 
+    @patch("merlin.model.DEFAULT_PREDICTION_JOB_DELAY", 0)
+    @patch("merlin.model.DEFAULT_PREDICTION_JOB_RETRY_DELAY", 0)
     @responses.activate
     def test_create_prediction_job_with_retry_failed(self, version):
         job_1.status = "pending"
@@ -416,6 +418,8 @@ class TestModelVersion:
             assert j.error == job_1.error
             assert j.name == job_1.name
 
+    @patch("merlin.model.DEFAULT_PREDICTION_JOB_DELAY", 0)
+    @patch("merlin.model.DEFAULT_PREDICTION_JOB_RETRY_DELAY", 0)
     @responses.activate
     def test_create_prediction_job_with_retry_success(self, version):
         job_1.status = "pending"
@@ -424,8 +428,7 @@ class TestModelVersion:
                       status=200,
                       content_type='application/json')
 
-        # Patch the method as currently it is not supported in the library itself
-        # I am going this way because this is a test, should be safe
+        # Patch the method as currently it is not supported in the library
         # https://github.com/getsentry/responses/issues/135
         def _find_match(self, request):
             for match in self._urls:
@@ -487,6 +490,8 @@ class TestModelVersion:
         # unpatch
         responses._find_match = types.MethodType(_find_match, responses)
 
+    @patch("merlin.model.DEFAULT_PREDICTION_JOB_DELAY", 0)
+    @patch("merlin.model.DEFAULT_PREDICTION_JOB_RETRY_DELAY", 0)
     @responses.activate
     def test_create_prediction_job_with_retry_pending_then_failed(self, version):
         job_1.status = "pending"
@@ -495,8 +500,7 @@ class TestModelVersion:
                       status=200,
                       content_type='application/json')
 
-        # Patch the method as currently it is not supported in the library itself
-        # I am going this way because this is a test, should be safe
+        # Patch the method as currently it is not supported in the library
         # https://github.com/getsentry/responses/issues/135
         def _find_match(self, request):
             for match in self._urls:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
This PR help to handle bug where an exception in the create_prediction_job API calls not handled and add retry between calls

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [x] Updated documentation
- [x] Update Swagger spec if the PR introduce API changes
- [x] Regenerated Golang and Python client if the PR introduce API changes
