### PR TITLE
Update API server to be able to filter listed model versions by their labels

### DIFF
--- a/api/service/version_service_it_test.go
+++ b/api/service/version_service_it_test.go
@@ -19,6 +19,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/google/uuid"
@@ -142,12 +143,33 @@ func TestVersionsService_ListVersions(t *testing.T) {
 		db.Create(&m)
 
 		numOfVersions := 10
-		indexEndpointActive := 9
+		indexEndpointActive := map[int]interface{}{
+			0: nil, 1: nil, 2: nil, 4: nil, 8: nil, 9: nil,
+		}
 		for i := 0; i < numOfVersions; i++ {
 			v := models.Version{
 				ModelID:     m.ID,
 				RunID:       fmt.Sprintf("%d", i+1),
 				ArtifactURI: "gcs:/mlp/1/1",
+				// Version objects will have these labels test cases:
+				// +----+------------+------------+------------+------------+
+				// | ID | label_key1 | label_val1 | label_key2 | label_val2 |
+				// +----+------------+------------+------------+------------+
+				// |  1 | foo        | foo0       | bar        | bar0       |
+				// |  2 | foo        | foo1       | bar        | bar1       |
+				// |  3 | foo        | foo2       | bar        | bar2       |
+				// |  4 | foo        | foo0       | bar        | bar3       |
+				// |  5 | foo        | foo1       | bar        | bar4       |
+				// |  6 | foo        | foo2       | bar        | bar0       |
+				// |  7 | foo        | foo0       | bar        | bar1       |
+				// |  8 | foo        | foo1       | bar        | bar2       |
+				// |  9 | foo        | foo2       | bar        | bar3       |
+				// | 10 | foo        | foo0       | bar        | bar4       |
+				// +----+------------+------------+------------+------------+
+				Labels: map[string]interface{}{
+					"foo": fmt.Sprintf("foo%d", i%3),
+					"bar": fmt.Sprintf("bar%d", i%5),
+				},
 			}
 			db.Create(&v)
 			endpoint1 := &models.VersionEndpoint{
@@ -169,7 +191,8 @@ func TestVersionsService_ListVersions(t *testing.T) {
 			db.Create(&endpoint2)
 
 			endpoint3Status := models.EndpointTerminated
-			if i == indexEndpointActive {
+
+			if _, ok := indexEndpointActive[i]; ok {
 				endpoint3Status = models.EndpointRunning
 			}
 			endpoint3 := &models.VersionEndpoint{
@@ -231,8 +254,8 @@ func TestVersionsService_ListVersions(t *testing.T) {
 			Search: "environment_name:env1",
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(versionsBasedOnEnv))
-		assert.Equal(t, "", cursor)
+		assert.Equal(t, 3, len(versionsBasedOnEnv))
+		assert.NotEmpty(t, cursor)
 
 		//search environment_name:env2 not exist env
 		versionsBasedOnEnv1, cursor1, err := versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
@@ -244,6 +267,138 @@ func TestVersionsService_ListVersions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(versionsBasedOnEnv1))
 		assert.Equal(t, "", cursor1)
+
+		//search environment_name:env1 and non-matching label
+		got, _, err := versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
+			Search: "environment_name:env1 labels:baz IN (qux)",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(got))
+
+		//search environment_name:env1 and matching 1 label key with single value
+		got, _, err = versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
+			Search: "environment_name:env1 labels:foo IN (foo0)",
+		})
+		wantIDs := []int{1, 10}
+		gotIDs := make([]int, 0)
+		for _, version := range got {
+			gotIDs = append(gotIDs, int(version.ID))
+		}
+		sort.Ints(gotIDs)
+		assert.NoError(t, err)
+		assert.Equal(t, len(wantIDs), len(got))
+		assert.Equal(t, wantIDs, gotIDs)
+
+		//search environment_name:env1 and matching 1 label key with multiple values
+		got, _, err = versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
+			Search: "environment_name:env1 labels:foo IN (foo0, foo1)",
+		})
+		wantIDs = []int{1, 2, 5, 10}
+		gotIDs = make([]int, 0)
+		for _, version := range got {
+			gotIDs = append(gotIDs, int(version.ID))
+		}
+		sort.Ints(gotIDs)
+		assert.NoError(t, err)
+		assert.Equal(t, len(wantIDs), len(got))
+		assert.Equal(t, wantIDs, gotIDs)
+
+		//search environment_name:env1 and matching multiple label key with some multiple values
+		got, _, err = versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
+			Search: "environment_name:env1 labels:foo IN (foo0), bar IN (bar1, bar4)",
+		})
+		wantIDs = []int{10}
+		gotIDs = make([]int, 0)
+		for _, version := range got {
+			gotIDs = append(gotIDs, int(version.ID))
+		}
+		sort.Ints(gotIDs)
+		assert.NoError(t, err)
+		assert.Equal(t, len(wantIDs), len(got))
+		assert.Equal(t, wantIDs, gotIDs)
+
+		//search environment_name:env1 and matching multiple label key with all multiple values
+		got, _, err = versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
+			Search: "environment_name:env1 labels:foo IN (foo0, foo1), bar IN (bar1, bar4)",
+		})
+		wantIDs = []int{2, 5, 10}
+		gotIDs = make([]int, 0)
+		for _, version := range got {
+			gotIDs = append(gotIDs, int(version.ID))
+		}
+		sort.Ints(gotIDs)
+		assert.NoError(t, err)
+		assert.Equal(t, len(wantIDs), len(got))
+		assert.Equal(t, wantIDs, gotIDs)
+
+		//search non-matching label
+		got, _, err = versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
+			Search: "labels:foo IN (foo0), megaman in (8), rockman in IN (x4,x5)",
+		})
+		wantIDs = make([]int, 0)
+		gotIDs = make([]int, 0)
+		for _, version := range got {
+			gotIDs = append(gotIDs, int(version.ID))
+		}
+		sort.Ints(gotIDs)
+		assert.NoError(t, err)
+		assert.Equal(t, len(wantIDs), len(got))
+
+		//search matching 1 label key with single value
+		got, _, err = versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
+			Search: "labels:foo IN (foo0)",
+		})
+		wantIDs = []int{1, 4, 7, 10}
+		gotIDs = make([]int, 0)
+		for _, version := range got {
+			gotIDs = append(gotIDs, int(version.ID))
+		}
+		sort.Ints(gotIDs)
+		assert.NoError(t, err)
+		assert.Equal(t, len(wantIDs), len(got))
+		assert.Equal(t, wantIDs, gotIDs)
+
+		//search matching 1 label key with multiple values
+		got, _, err = versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
+			Search: "labels:foo IN (foo0, foo2)",
+		})
+		wantIDs = []int{1, 3, 4, 6, 7, 9, 10}
+		gotIDs = make([]int, 0)
+		for _, version := range got {
+			gotIDs = append(gotIDs, int(version.ID))
+		}
+		sort.Ints(gotIDs)
+		assert.NoError(t, err)
+		assert.Equal(t, len(wantIDs), len(got))
+		assert.Equal(t, wantIDs, gotIDs)
+
+		//search matching multiple label key with some multiple values
+		got, _, err = versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
+			Search: "labels:foo IN (foo0), bar IN (bar1, bar4)",
+		})
+		wantIDs = []int{7, 10}
+		gotIDs = make([]int, 0)
+		for _, version := range got {
+			gotIDs = append(gotIDs, int(version.ID))
+		}
+		sort.Ints(gotIDs)
+		assert.NoError(t, err)
+		assert.Equal(t, len(wantIDs), len(got))
+		assert.Equal(t, wantIDs, gotIDs)
+
+		//search environment_name:env1 and matching multiple label key with all multiple values
+		got, _, err = versionsService.ListVersions(context.Background(), m.ID, config.MonitoringConfig{MonitoringEnabled: true}, VersionQuery{
+			Search: "labels:foo IN (foo0, foo1), bar IN (bar1, bar4)",
+		})
+		wantIDs = []int{2, 5, 7, 10}
+		gotIDs = make([]int, 0)
+		for _, version := range got {
+			gotIDs = append(gotIDs, int(version.ID))
+		}
+		sort.Ints(gotIDs)
+		assert.NoError(t, err)
+		assert.Equal(t, len(wantIDs), len(got))
+		assert.Equal(t, wantIDs, gotIDs)
 	})
 }
 

--- a/api/service/version_service_test.go
+++ b/api/service/version_service_test.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_getVersionSearchTerms(t *testing.T) {
+	type args struct {
+		query string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "empty query",
+			args: args{""},
+			want: map[string]string{},
+		},
+		{
+			name: "empty query with whitespaces",
+			args: args{"  "},
+			want: map[string]string{},
+		},
+		{
+			name: "single key empty value",
+			args: args{"foo:"},
+			want: map[string]string{"foo":""},
+		},
+		{
+			name: "single key empty value with whitespaces",
+			args: args{"foo :    "},
+			want: map[string]string{"foo":""},
+		},
+		{
+			name: "single key non-empty value",
+			args: args{"foo: bar"},
+			want: map[string]string{"foo": "bar"},
+		},
+		{
+			name: "single key non-empty value with whitespaces",
+			args: args{"foo     :bar"},
+			want: map[string]string{"foo": "bar"},
+		},
+		{
+			name: "multiple keys with empty key",
+			args: args{"foo::bar"},
+			want: map[string]string{"foo": ""},
+		},
+		{
+			name: "multiple keys with empty key and whitespaces",
+			args: args{"foo :     : bar"},
+			want: map[string]string{"foo": ""},
+		},
+		{
+			name: "multiple keys and some empty values",
+			args: args{"foo:bar:baz"},
+			want: map[string]string{"foo": "", "bar": "baz"},
+		},
+		{
+			name: "multiple keys with empty key and values",
+			args: args{"foo:bar::"},
+			want: map[string]string{"foo": "", "bar": ""},
+		},
+		{
+			name: "multiple keys and non-empty values",
+			args: args{"foo:bar baz:qux quux "},
+			want: map[string]string{"foo": "bar", "baz": "qux quux"},
+		},
+		{
+			name: "duplicate keys and non-empty values",
+			args: args{"foo:bar baz:qux quux foo: corge"},
+			want: map[string]string{"foo": "corge", "baz": "qux quux"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getVersionSearchTerms(tt.args.query); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getVersionSearchTerms() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -262,6 +262,13 @@ paths:
           name: "search"
           type: "string"
           required: false
+          description: |
+            Search query to filter the model versions. These searches are currently supported:
+            - Search by "mlflow_run_id" e.g. `?search=cfca7716b45f4b149479630a98332a13`
+            - Search by "environment_name" e.g `?search=environment_name:myenv`
+            - Search by "labels" e.g. `?search=labels:app IN (nginx,postgres), country in (SG)`
+            - Search by "environment_name" and "labels" e.g. 
+              `?search=environment_name:myenv labels:app IN (nginx,postgres), country in (SG)`
       responses:
         200:
           description: "OK"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Update API server to support listing model versions object filtered by the model version labels.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

Clients of the API server can now search by model version labels when listing model versions.
For this REST endpoint: `GET http//baseurl//models/{model_id}/versions`, the following value combinations for `search` query parameter are now supported:
- Filter by mlflow_run_id: `?search=cfca7716b45f4b149479630a98332a13`
- Filter by environment_name:  `?environment_name=myenv`
- (This PR) Filter by labels: `?search=labels:segment IN (s1,s2), country in (SG)`
- (This PR) Filter by environment_name and labels: `?search=environment_name=myenv labels:segment IN (s1,s2), country in (SG)`


**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [x] Updated documentation
- [x] Update Swagger spec if the PR introduce API changes
- [x] Regenerated Golang and Python client if the PR introduce API changes
