### PR TITLE
Add S2ID UDF

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gojek/merlin-pyspark-app v0.0.3
 	github.com/gojek/mlp v0.0.0-20201002030420-4e35e69a9ab8
 	github.com/golang-migrate/migrate/v4 v4.11.0
+	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-containerregistry v0.0.0-20191009212737-d753c5604768
 	github.com/google/uuid v1.1.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -426,6 +426,8 @@ github.com/gojek/mlp v0.0.0-20201002030420-4e35e69a9ab8 h1:S0k9mBbISxJGRUYetI+IK
 github.com/gojek/mlp v0.0.0-20201002030420-4e35e69a9ab8/go.mod h1:IjQCiAzap7TZRZVZ4r2RdzVTuAzoyR5el2GgEu2X1FM=
 github.com/golang-migrate/migrate/v4 v4.11.0 h1:uqtd0ysK5WyBQ/T1K2uDIooJV0o2Obt6uPwP062DupQ=
 github.com/golang-migrate/migrate/v4 v4.11.0/go.mod h1:nqbpDbckcYjsCD5I8q5+NI9Tkk7SVcmaF40Ax1eAWhg=
+github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 h1:gtexQ/VGyN+VVFRXSFiguSNcXmS6rkKT+X7FdIrTtfo=
+github.com/golang/geo v0.0.0-20210211234256-740aa86cb551/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/api/pkg/transformer/feast/entity_extractor_test.go
+++ b/api/pkg/transformer/feast/entity_extractor_test.go
@@ -348,6 +348,20 @@ func TestGetValuesFromJSONPayload(t *testing.T) {
 			nil,
 		},
 		{
+			"S2ID udf",
+			&transformer.Entity{
+				Name:      "s2id",
+				ValueType: "STRING",
+				Extractor: &transformer.Entity_Udf{
+					Udf: "S2ID(\"$.latitude\", \"$.longitude\", 12)",
+				},
+			},
+			[]*feastType.Value{
+				feast.StrVal("1154732743855177728"),
+			},
+			nil,
+		},
+		{
 			"unsupported feast type",
 			&transformer.Entity{
 				Name:      "my_entity",

--- a/api/pkg/transformer/feast/transformer_test.go
+++ b/api/pkg/transformer/feast/transformer_test.go
@@ -1191,6 +1191,65 @@ func TestTransformer_Transform(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "s2id entity from latitude and longitude",
+			fields: fields{
+				config: &transformer.StandardTransformerConfig{
+					TransformerConfig: &transformer.TransformerConfig{
+						Feast: []*transformer.FeatureTable{
+							{
+								Project: "s2id",
+								Entities: []*transformer.Entity{
+									{
+										Name:      "s2id",
+										ValueType: "STRING",
+										Extractor: &transformer.Entity_Udf{
+											Udf: "S2ID(\"$.latitude\", \"$.longitude\", 12)",
+										},
+									},
+								},
+								Features: []*transformer.Feature{
+									{
+										Name:         "geohash_statistics:average_daily_rides",
+										DefaultValue: "0.0",
+										ValueType:    "DOUBLE",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				ctx:     context.Background(),
+				request: []byte(`{"latitude":1.0,"longitude":2.0}`),
+			},
+			mockFeast: []mockFeast{
+				{
+					request: &feast.OnlineFeaturesRequest{
+						Project: "s2id",
+					},
+					response: &feast.OnlineFeaturesResponse{
+						RawResponse: &serving.GetOnlineFeaturesResponse{
+							FieldValues: []*serving.GetOnlineFeaturesResponse_FieldValues{
+								{
+									Fields: map[string]*types.Value{
+										"geohash_statistics:average_daily_rides": feast.DoubleVal(3.2),
+										"s2id":                                feast.StrVal("1154732743855177728"),
+									},
+									Statuses: map[string]serving.GetOnlineFeaturesResponse_FieldStatus{
+										"geohash_statistics:average_daily_rides": serving.GetOnlineFeaturesResponse_PRESENT,
+										"s2id":                                serving.GetOnlineFeaturesResponse_PRESENT,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    []byte(`{"latitude":1.0,"longitude":2.0,"feast_features":{"s2id":{"columns":["s2id","geohash_statistics:average_daily_rides"],"data":[["1154732743855177728",3.2]]}}}`),
+			wantErr: false,
+		},
+		{
 			name: "one config: retrieve multiple entities, one feature, batch",
 			fields: fields{
 				config: &transformer.StandardTransformerConfig{

--- a/api/pkg/transformer/feast/udf_test.go
+++ b/api/pkg/transformer/feast/udf_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestExtractGeohash(t *testing.T) {
+func TestGeohash(t *testing.T) {
 	testJsonString := []byte(`{
 		"latitude" : 1.0,
 		"latitudeString": "1.0",
@@ -93,16 +93,116 @@ func TestExtractGeohash(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, err := extractGeohash(testJsonUnmarshallled, test.latitudeJsonPath, test.longitudeJsonPath, test.precision)
-			if err != nil {
+			udf := &UdfEnv{UnmarshalledJsonRequest:testJsonUnmarshallled}
+			udfResult := udf.Geohash(test.latitudeJsonPath, test.longitudeJsonPath, test.precision)
+			if udfResult.Error != nil {
 				if test.expError != nil {
-					assert.EqualError(t, err, test.expError.Error())
+					assert.EqualError(t, udfResult.Error, test.expError.Error())
 					return
 				} else {
-					assert.Fail(t, err.Error())
+					assert.Fail(t, udfResult.Error.Error())
 				}
 			}
-			assert.Equal(t, test.expValue, actual)
+			assert.Equal(t, test.expValue, udfResult.Value)
+		})
+	}
+}
+
+func TestS2ID(t *testing.T) {
+	testJsonString := []byte(`{
+		"latitude" : 1.0,
+		"latitudeString": "1.0",
+		"latitudeWrongType": "abcde",
+		"location": {
+			"latitude": 0.1,
+			"longitude": 2.0
+		},
+		"latitudeArrays": [1.0, 2.0],
+		"longitude" : 2.0,
+		"longitudeString" : "2.0",
+		"longitudeInteger": 1,
+		"longitudeArrays": [1.0, 2.0],
+		"longitudeLongArrays": [1.0, 2.0, 3.0]
+	}`)
+	var testJsonUnmarshallled interface{}
+	err := json.Unmarshal(testJsonString, &testJsonUnmarshallled)
+	if err != nil {
+		panic(err)
+	}
+
+	tests := []struct {
+		name              string
+		latitudeJsonPath  string
+		longitudeJsonPath string
+		level             int
+		expValue          interface{}
+		expError          error
+	}{
+		{
+			name:              "geohash from json fields",
+			latitudeJsonPath:  "$.latitude",
+			longitudeJsonPath: "$.longitude",
+			level:             7,
+			expValue:          "1154680723211288576",
+		},
+		{
+			name:              "geohash from json struct",
+			latitudeJsonPath:  "$.location.latitude",
+			longitudeJsonPath: "$.location.longitude",
+			level:             7,
+			expValue:          "1155102935676354560",
+		},
+		{
+			name:              "type conversion for latitude and longitude input",
+			latitudeJsonPath:  "$.latitudeString",
+			longitudeJsonPath: "$.longitudeString",
+			level:             12,
+			expValue:          "1154732743855177728",
+		},
+		{
+			name:              "Type difference error",
+			latitudeJsonPath:  "$.latitude",
+			longitudeJsonPath: "$.longitudeArrays",
+			expError:          errors.New("latitude and longitude must have the same types"),
+		},
+		{
+			name:              "type conversion error",
+			latitudeJsonPath:  "$.latitudeWrongType",
+			longitudeJsonPath: "$.longitudeString",
+			expError:          errors.New("strconv.ParseFloat: parsing \"abcde\": invalid syntax"),
+		},
+		{
+			name:              "array length difference error",
+			latitudeJsonPath:  "$.latitudeArrays",
+			longitudeJsonPath: "$.longitudeLongArrays",
+			level:             12,
+			expError:          errors.New("both latitude and longitude arrays must have the same length"),
+		},
+		{
+			name:              "latitude and longitude arrays",
+			latitudeJsonPath:  "$.latitudeArrays",
+			longitudeJsonPath: "$.longitudeArrays",
+			level:             12,
+			expValue: []string{
+				"1153277815093723136",
+				"1154346540395921408",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			udf := &UdfEnv{UnmarshalledJsonRequest:testJsonUnmarshallled}
+			udfResult := udf.S2ID(test.latitudeJsonPath, test.longitudeJsonPath, test.level)
+			if udfResult.Error != nil {
+				if test.expError != nil {
+					assert.EqualError(t, udfResult.Error, test.expError.Error())
+					return
+				} else {
+					assert.Fail(t, udfResult.Error.Error())
+				}
+			}
+			assert.Equal(t, test.expValue, udfResult.Value)
 		})
 	}
 }

--- a/docs/user-guide/transformer.md
+++ b/docs/user-guide/transformer.md
@@ -134,6 +134,28 @@ Config
 
 Output: `"9001"`
 
+#### S2ID
+Takes in JsonPath to latitude and longitude, and an additional level parameter to generate the s2id
+
+##### Example
+
+Input
+```json
+{
+  "latitude":1.0,
+  "longitude":2.0
+}
+```
+
+Config
+```yaml
+- name: s2id
+  valueType: STRING
+  udf: Geohash($.latitude, $.longitude, 12)
+```
+
+Output: `"1154732743855177728"`
+
 ### Standard Transformer Response Output
 
 The output of the standard transformer becomes the input to your model. Here’s we describe how it looks like so you can consume it correctly in your model.

--- a/docs/user-guide/transformer.md
+++ b/docs/user-guide/transformer.md
@@ -151,7 +151,7 @@ Config
 ```yaml
 - name: s2id
   valueType: STRING
-  udf: Geohash($.latitude, $.longitude, 12)
+  udf: S2ID($.latitude, $.longitude, 12)
 ```
 
 Output: `"1154732743855177728"`


### PR DESCRIPTION
**What this PR does / why we need it**:
S2ID computation function is added which can be used to convert latlong to S2ID.

For example, given this JSON:
```json
{
  "latitude":1.0,
  "longitude":2.0
}
```
The method `Geohash($.latitude, $.longitude, 12)` can be used to get output `1154732743855177728`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [X] Added unit test, integration, and/or e2e tests
- [X] Tested locally
- [X] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
