### PR TITLE
Support UDF syntax in Entities UI

### DIFF
--- a/ui/src/services/transformer/TransformerConfig.js
+++ b/ui/src/services/transformer/TransformerConfig.js
@@ -19,10 +19,11 @@ const objectAssignDeep = require(`object-assign-deep`);
 export const STANDARD_TRANSFORMER_CONFIG_ENV_NAME =
   "STANDARD_TRANSFORMER_CONFIG";
 export class Entity {
-  constructor(name, valueType, jsonPath) {
+  constructor(name, valueType, jsonPath, udf) {
     this.name = name;
     this.valueType = valueType;
     this.jsonPath = jsonPath;
+    this.udf = udf;
   }
 }
 

--- a/ui/src/version/deployment/components/EndpointDeployment.js
+++ b/ui/src/version/deployment/components/EndpointDeployment.js
@@ -209,7 +209,7 @@ export const EndpointDeployment = ({
       <EuiSpacer size="l" />
 
       <EuiFlexGroup justifyContent="spaceAround">
-        <EuiFlexItem style={{ maxWidth: 700 }}>
+        <EuiFlexItem style={{ maxWidth: 1200 }}>
           <EuiForm
             isInvalid={!!response.error}
             error={response.error ? [response.error.message] : ""}>

--- a/ui/src/version/deployment/components/FeastEntities.js
+++ b/ui/src/version/deployment/components/FeastEntities.js
@@ -174,7 +174,7 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
     {
       name: "Value Type",
       field: "valueType",
-      width: "25%",
+      width: "20%",
       render: (value, item) => (
         <EuiComboBox
           fullWidth
@@ -193,7 +193,7 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
     {
       name: "Field Type",
       field: "fieldType",
-      width: "30%",
+      width: "15%",
       render: (value, item) => (
         <EuiComboBox
           fullWidth
@@ -218,7 +218,7 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
         </EuiToolTip>
       ),
       field: "jsonPath",
-      width: "20%",
+      width: "35%",
       render: (value, item) => (
         <EuiFieldText
           controlOnly
@@ -230,7 +230,7 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
       )
     },
     {
-      width: "10%",
+      width: "5%",
       actions: [
         {
           render: item => {

--- a/ui/src/version/deployment/components/FeastEntities.js
+++ b/ui/src/version/deployment/components/FeastEntities.js
@@ -91,6 +91,7 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
         const updatedItems = items.slice(0, items.length - 1).map(item => ({
           name: item.name,
           valueType: item.valueType,
+          fieldType: item.fieldType,
           jsonPath: item.jsonPath
         }));
         onChange(updatedItems);
@@ -111,7 +112,8 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
     setItems(_ =>
       items[items.length - 1].name &&
       items[items.length - 1].valueType &&
-      items[items.length - 1].jsonPath
+      items[items.length - 1].jsonPath &&
+      items[items.length - 1].fieldType
         ? [...items, { idx: items.length }]
         : [...items]
     );
@@ -172,7 +174,7 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
     {
       name: "Value Type",
       field: "valueType",
-      width: "30%",
+      width: "25%",
       render: (value, item) => (
         <EuiComboBox
           fullWidth
@@ -189,20 +191,39 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
       )
     },
     {
+      name: "Field Type",
+      field: "fieldType",
+      width: "30%",
+      render: (value, item) => (
+        <EuiComboBox
+          fullWidth
+          singleSelection={{ asPlainText: true }}
+          isClearable={false}
+          placeholder="Field Type"
+          options={[{ label: "JSONPath" }, { label: "UDF" }]}
+          onChange={onEntityChange(item.idx, "fieldType")}
+          onCreateOption={searchValue =>
+            onEntityCreate(searchValue, item.idx, "fieldType")
+          }
+          selectedOptions={getSelectedOption(value)}
+        />
+      )
+    },
+    {
       name: (
-        <EuiToolTip content="Specify the JSONPath syntax to extract entity value from the request payload.">
+        <EuiToolTip content="Specify the JSONPath/UDF syntax to extract entity value from the request payload.">
           <span>
-            JSONPath <EuiIcon type="questionInCircle" color="subdued" />
+            Field <EuiIcon type="questionInCircle" color="subdued" />
           </span>
         </EuiToolTip>
       ),
       field: "jsonPath",
-      width: "30%",
+      width: "20%",
       render: (value, item) => (
         <EuiFieldText
           controlOnly
           fullWidth
-          placeholder="JSON Path"
+          placeholder="Field"
           value={value || ""}
           onChange={onChangeRow(item.idx, "jsonPath")}
         />

--- a/ui/src/version/deployment/components/StandardTransformerForm.js
+++ b/ui/src/version/deployment/components/StandardTransformerForm.js
@@ -99,7 +99,7 @@ export const StandardTransformerForm = ({ transformer, onChange }) => {
         config.transformerConfig.feast &&
         transformer.env_vars
       ) {
-        const newConfigJSON = JSON.stringify(config);
+        const newConfigJSON = JSON.stringify(transformToConfigJSON(config));
         // Find the index of env_var that contains transformer config
         // If it's not exist, create new env var
         // If it's exist, update it
@@ -217,11 +217,27 @@ export const StandardTransformerForm = ({ transformer, onChange }) => {
         buttonContent={<EuiText size="xs">See YAML configuration</EuiText>}
         paddingSize="m">
         <EuiCodeBlock language="yaml" fontSize="m" paddingSize="m" isCopyable>
-          {yaml.dump(config)}
+          {yaml.dump(transformToConfigJSON(config))}
         </EuiCodeBlock>
       </EuiAccordion>
     </>
   );
+};
+
+const transformToConfigJSON = config => {
+  let output = JSON.parse(JSON.stringify(config));
+  if (output.transformerConfig) {
+    output.transformerConfig.feast.forEach(feastConfig => {
+      feastConfig.entities.forEach(entity => {
+        if (entity.fieldType === "UDF") {
+          entity["udf"] = entity.jsonPath;
+          delete entity["jsonPath"];
+        }
+        delete entity["fieldType"];
+      });
+    });
+  }
+  return output;
 };
 
 StandardTransformerForm.propTypes = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a dropdown column to allow user to specify field type to be UDF or JSONPath.

UDF
![image](https://user-images.githubusercontent.com/5955220/109813603-897c4d80-7c68-11eb-8f3f-ce8773f672fd.png)

![image](https://user-images.githubusercontent.com/5955220/109813973-fa236a00-7c68-11eb-83da-96e92d5f0c91.png)


JSONPath
![image](https://user-images.githubusercontent.com/5955220/109813643-99942d00-7c68-11eb-9209-9676a3bebcba.png)

![image](https://user-images.githubusercontent.com/5955220/109813923-ebd54e00-7c68-11eb-8473-01dfc4486366.png)



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [X] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
