### PR TITLE
Fix UI bug where existing env var is not read properly for standard transformer

### DIFF
--- a/ui/src/version/deployment/components/FeastEntities.js
+++ b/ui/src/version/deployment/components/FeastEntities.js
@@ -92,7 +92,7 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
           name: item.name,
           valueType: item.valueType,
           fieldType: item.fieldType,
-          jsonPath: item.jsonPath
+          field: item.field
         }));
         onChange(updatedItems);
       } else {
@@ -112,7 +112,7 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
     setItems(_ =>
       items[items.length - 1].name &&
       items[items.length - 1].valueType &&
-      items[items.length - 1].jsonPath &&
+      items[items.length - 1].field &&
       items[items.length - 1].fieldType
         ? [...items, { idx: items.length }]
         : [...items]
@@ -217,7 +217,7 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
           </span>
         </EuiToolTip>
       ),
-      field: "jsonPath",
+      field: "field",
       width: "35%",
       render: (value, item) => (
         <EuiFieldText
@@ -225,7 +225,7 @@ export const FeastEntities = ({ entities, feastEntities, onChange }) => {
           fullWidth
           placeholder="Field"
           value={value || ""}
-          onChange={onChangeRow(item.idx, "jsonPath")}
+          onChange={onChangeRow(item.idx, "field")}
         />
       )
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix UI bug where existing env var is not read properly for standard transformer

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #94

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
