### PR TITLE
Add client side grpc load balancing to feast core

### DIFF
--- a/api/cluster/templater_test.go
+++ b/api/cluster/templater_test.go
@@ -92,6 +92,7 @@ var (
 		ImageName:       "merlin-standard-transformer",
 		FeastServingURL: "serving.feast.dev:8081",
 		FeastCoreURL:    "core.feast.dev:8081",
+		ClientLoadBalancingEnabled: true,
 	}
 )
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -140,6 +140,7 @@ type StandardTransformerConfig struct {
 	ImageName       string `envconfig:"STANDARD_TRANSFORMER_IMAGE_NAME" required:"true"`
 	FeastServingURL string `envconfig:"FEAST_SERVING_URL" required:"true"`
 	FeastCoreURL    string `envconfig:"FEAST_CORE_URL" required:"true"`
+	ClientLoadBalancingEnabled bool `envconfig:"CLIENT_LOAD_BALANCING_ENABLED" default:"false"`
 }
 
 type MlflowConfig struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add client side grpc load balancing to feast core, which can be controlled by environment variable `CLIENT_LOAD_BALANCING_ENABLED`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
