### PR TITLE
Adding project as one of table name and cache key

### DIFF
--- a/api/pkg/transformer/feast/transformer.go
+++ b/api/pkg/transformer/feast/transformer.go
@@ -473,7 +473,7 @@ func createTableName(entities []*transformer.Entity, project string) string {
 
 	tableName := strings.Join(entityNames, "_")
 	if project != defaultProjectName {
-		tableName = tableName + "_" + project
+		tableName = project + "_" + tableName
 	}
 
 	return tableName

--- a/api/pkg/transformer/feast/transformer.go
+++ b/api/pkg/transformer/feast/transformer.go
@@ -65,6 +65,8 @@ var (
 	})
 )
 
+const defaultProjectName = "default"
+
 // Options for the Feast transformer.
 type Options struct {
 	ServingURL              string        `envconfig:"FEAST_SERVING_URL" required:"true"`
@@ -170,7 +172,7 @@ func (t *Transformer) Transform(ctx context.Context, request []byte) ([]byte, er
 	resChan := make(chan result, len(t.config.TransformerConfig.Feast))
 	for _, config := range t.config.TransformerConfig.Feast {
 		go func(cfg *transformer.FeatureTable) {
-			tableName := createTableName(cfg.Entities)
+			tableName := createTableName(cfg.Entities, cfg.Project)
 			val, err := t.getFeastFeature(ctx, tableName, request, cfg)
 			resChan <- result{tableName, val, err}
 		}(config)
@@ -226,7 +228,7 @@ func (t *Transformer) getFeatureFromFeast(ctx context.Context, entities []feast.
 	entityNotInCache := entities
 
 	if t.options.CacheEnabled {
-		cachedValues, entityNotInCache = fetchFeaturesFromCache(t.cache, entities)
+		cachedValues, entityNotInCache = fetchFeaturesFromCache(t.cache, entities, config.Project)
 	}
 
 	numOfBatchBeforeCeil := float64(len(entityNotInCache)) / float64(t.options.BatchSize)
@@ -275,7 +277,7 @@ func (t *Transformer) getFeatureFromFeast(ctx context.Context, entities []feast.
 			}
 
 			if t.options.CacheEnabled {
-				if err := insertMultipleFeaturesToCache(t.cache, entityFeaturePairs, t.options.CacheTTL); err != nil {
+				if err := insertMultipleFeaturesToCache(t.cache, entityFeaturePairs, project, t.options.CacheTTL); err != nil {
 					t.logger.Error("insert_to_cache", zap.Any("error", err))
 				}
 			}
@@ -381,8 +383,8 @@ func (t *Transformer) buildEntitiesRequest(ctx context.Context, request []byte, 
 }
 
 type entityFeaturePair struct {
-	key   feast.Row
-	value FeatureData
+	entity feast.Row
+	value  FeatureData
 }
 
 func (t *Transformer) buildFeastFeaturesData(ctx context.Context, feastResponse *feast.OnlineFeaturesResponse, columns []string, entityIndexMap map[int]int) ([]entityFeaturePair, error) {
@@ -442,7 +444,7 @@ func (t *Transformer) buildFeastFeaturesData(ctx context.Context, feastResponse 
 				feastFeatureStatus.WithLabelValues(column, featureStatus.String()).Inc()
 			}
 		}
-		data = append(data, entityFeaturePair{key: entity, value: row})
+		data = append(data, entityFeaturePair{entity: entity, value: row})
 	}
 
 	return data, nil
@@ -463,13 +465,18 @@ func getFloatValue(val interface{}) (float64, error) {
 	}
 }
 
-func createTableName(entities []*transformer.Entity) string {
+func createTableName(entities []*transformer.Entity, project string) string {
 	entityNames := make([]string, 0)
 	for _, n := range entities {
 		entityNames = append(entityNames, n.Name)
 	}
 
-	return strings.Join(entityNames, "_")
+	tableName := strings.Join(entityNames, "_")
+	if project != defaultProjectName {
+		tableName = tableName + "_" + project
+	}
+
+	return tableName
 }
 
 func getFeatureValue(val *types.Value) (interface{}, error) {

--- a/api/pkg/transformer/feast/transformer_test.go
+++ b/api/pkg/transformer/feast/transformer_test.go
@@ -587,7 +587,7 @@ func TestTransformer_Transform_With_Batching_Cache(t *testing.T) {
 				},
 			},
 			wantErr: false,
-			want:    []byte(`{"drivers":[{"id":"1001"},{"id":"2002"}],"merchants":[{"id":"1"},{"id":"2"}],"customer_id":1,"feast_features":{"driver_id":{"columns":["driver_id","driver_trips:average_daily_rides"],"data":[["1001",1.1],null]},"merchant_uuid_customer_id_project":{"columns":["merchant_uuid","customer_id","customer_merchant_interaction:int_order_count_24weeks"],"data":[["2",1,20],["1",1,10]]}}}`),
+			want:    []byte(`{"drivers":[{"id":"1001"},{"id":"2002"}],"merchants":[{"id":"1"},{"id":"2"}],"customer_id":1,"feast_features":{"driver_id":{"columns":["driver_id","driver_trips:average_daily_rides"],"data":[["1001",1.1],null]},"project_merchant_uuid_customer_id":{"columns":["merchant_uuid","customer_id","customer_merchant_interaction:int_order_count_24weeks"],"data":[["2",1,20],["1",1,10]]}}}`),
 		},
 		{
 			name: "one config: retrieve multiple entities, 2 feature tables but same entity name, batched",
@@ -740,7 +740,7 @@ func TestTransformer_Transform_With_Batching_Cache(t *testing.T) {
 					},
 				},
 			},
-			want:    []byte(`{"drivers":[{"id": "1001"},{"id": "2002"}],"feast_features":{"driver_id":{"columns":["driver_id","driver_trips:average_daily_rides"],"data":[["1001",1.1],["2002",2.2]]},"driver_id_sample":{"columns":["driver_id","driver_trips:avg_rating"],"data":[["1001",4.5],["2002",5]]}}}`),
+			want:    []byte(`{"drivers":[{"id": "1001"},{"id": "2002"}],"feast_features":{"driver_id":{"columns":["driver_id","driver_trips:average_daily_rides"],"data":[["1001",1.1],["2002",2.2]]},"sample_driver_id":{"columns":["driver_id","driver_trips:avg_rating"],"data":[["1001",4.5],["2002",5]]}}}`),
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Currently table name of features and cache key only take entities as identifier. This PR will add project in featureTableName and cache key 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
