### PR TITLE
Fix entity conversion for large integer

### DIFF
--- a/api/pkg/transformer/feast/entity_extractor.go
+++ b/api/pkg/transformer/feast/entity_extractor.go
@@ -131,7 +131,14 @@ func getValue(v interface{}, valueType feastType.ValueType_Enum) (*feastType.Val
 			return nil, fmt.Errorf("unsupported conversion from %T to BOOL", v)
 		}
 	case feastType.ValueType_STRING:
-		return feast.StrVal(fmt.Sprintf("%v", v)), nil
+		switch v.(type) {
+		case float64:
+			// we'll truncate decimal point as number in json is treated as float64 and it doesn't make sense to have decimal as entity id
+			return feast.StrVal(fmt.Sprintf("%.0f", v.(float64))), nil
+		default:
+			return feast.StrVal(fmt.Sprintf("%v", v)), nil
+		}
+
 	default:
 		return nil, fmt.Errorf("unsupported type %s", valueType.String())
 	}

--- a/api/pkg/transformer/feast/entity_extractor_test.go
+++ b/api/pkg/transformer/feast/entity_extractor_test.go
@@ -24,6 +24,7 @@ func TestGetValuesFromJSONPayload(t *testing.T) {
 		"booleanString" : "false",
 		"latitude": 1.0,
 		"longitude": 2.0,
+		"longInteger": 12986086,
 		"locations": [
 		 {
 			"latitude": 1.0,
@@ -119,6 +120,20 @@ func TestGetValuesFromJSONPayload(t *testing.T) {
 			nil,
 		},
 		{
+			"long integer to string",
+			&transformer.Entity{
+				Name:      "my_entity",
+				ValueType: "STRING",
+				Extractor: &transformer.Entity_JsonPath{
+					JsonPath: "$.longInteger",
+				},
+			},
+			[]*feastType.Value{
+				feast.StrVal("12986086"),
+			},
+			nil,
+		},
+		{
 			"float to int32",
 			&transformer.Entity{
 				Name:      "my_entity",
@@ -184,7 +199,7 @@ func TestGetValuesFromJSONPayload(t *testing.T) {
 				},
 			},
 			[]*feastType.Value{
-				feast.StrVal("1234.111"),
+				feast.StrVal("1234"),
 			},
 			nil,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Fix entity conversion from large integer into string.
Large integer in JSON is treated as float64 thus when converted to string it will contain point decimal and possibly in exponent format. e.g. for number 12986086 it will be converted into "1.2986086e+07".
With this change, the conversion will treat it as integer.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
