### PR TITLE
Include project name in error message when entity is not found

### DIFF
--- a/api/pkg/transformer/feast/validator.go
+++ b/api/pkg/transformer/feast/validator.go
@@ -57,7 +57,7 @@ func ValidateTransformerConfig(ctx context.Context, coreClient core.CoreServiceC
 		for _, entity := range config.Entities {
 			spec, found := allEntities[entity.Name]
 			if !found {
-				return NewValidationError("entity not found: " + entity.Name)
+				return NewValidationError(fmt.Sprintf("entity %s is not found in project %s", entity.Name, config.Project))
 			}
 
 			switch entity.Extractor.(type) {

--- a/api/pkg/transformer/feast/validator_test.go
+++ b/api/pkg/transformer/feast/validator_test.go
@@ -93,7 +93,7 @@ func TestValidateTransformerConfig(t *testing.T) {
 			},
 			&core.ListEntitiesResponse{},
 			nil,
-			NewValidationError("entity not found: customer_id"),
+			NewValidationError("entity customer_id is not found in project default"),
 		},
 		{
 			"extractor not specified",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
A small improvement for standard transformer validation. Error message related to missing entity currently is not ideal since it doesn't mention the project name.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
