### PR TITLE
Add additional built-in function and compact standard transformer con…

### DIFF
--- a/api/cluster/templater_test.go
+++ b/api/cluster/templater_test.go
@@ -633,6 +633,12 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 				Transformer: &models.Transformer{
 					Enabled:         true,
 					TransformerType: models.StandardTransformerType,
+					EnvVars: models.EnvVars{
+						{
+							Name:  transformer.StandardTransformerConfigEnvName,
+							Value: `  { "standard_transformer": null}`,
+						},
+					},
 				},
 				Logger: &models.Logger{
 					DestinationURL: loggerDestinationURL,
@@ -676,6 +682,7 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 									Name:  "transformer",
 									Image: standardTransformerConfig.ImageName,
 									Env: []v1.EnvVar{
+										{Name: transformer.StandardTransformerConfigEnvName, Value: `{"standard_transformer":null}`},
 										{Name: transformer.FeastServingURLEnvName, Value: standardTransformerConfig.FeastServingURL},
 										{Name: envTransformerPort, Value: defaultTransformerPort},
 										{Name: envTransformerModelName, Value: "model-1"},

--- a/api/go.sum
+++ b/api/go.sum
@@ -721,7 +721,6 @@ github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180723221831-d5012789d665/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/api/pkg/transformer/symbol/function/geospatial.go
+++ b/api/pkg/transformer/symbol/function/geospatial.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	earthRaidusKm = 6371 // radius of the earth in kilometers.
-	pointFive     = 0.5
+	earthRaidusKm   = 6371 // radius of the earth in kilometers.
+	pointFive       = 0.5
+	zero            = 0
+	minimumDistance = 1.0
 )
 
 type LatLong struct {
@@ -114,6 +116,8 @@ func PolarAngle(lat1 interface{}, lon1 interface{}, lat2 interface{}, lon2 inter
 	}
 }
 
+// Haversine distance calculate distance between to points (lat, lon) in km
+// lat1, lon1, lat2, lon2 should be float64 or []float64 or any value that can be converted to those types (float64 or []float64)
 func HaversineDistance(lat1 interface{}, lon1 interface{}, lat2 interface{}, lon2 interface{}) (interface{}, error) {
 	firstPoint, err := extractLatLong(lat1, lon1)
 	if err != nil {
@@ -177,6 +181,10 @@ func calculateDistance(firstPoint *LatLong, secondPoint *LatLong) float64 {
 }
 
 func calculatePolarAngle(firstPoint *LatLong, secondPoint *LatLong) float64 {
+	distance := calculateDistance(firstPoint, secondPoint)
+	if distance < minimumDistance {
+		return zero
+	}
 	lat1 := degreesToRadians(firstPoint.lat)
 	lon1 := degreesToRadians(firstPoint.long)
 	lat2 := degreesToRadians(secondPoint.lat)

--- a/api/pkg/transformer/symbol/function/geospatial.go
+++ b/api/pkg/transformer/symbol/function/geospatial.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	earthRaidusKm   = 6371 // radius of the earth in kilometers.
-	pointFive       = 0.5
-	zero            = 0
-	minimumDistance = 1.0
+	earthRadiusKm       = 6371 // radius of the earth in kilometers.
+	pointFive           = 0.5
+	zero                = 0
+	minimumDistanceInKM = 0.001 // 1 meter
 )
 
 type LatLong struct {
@@ -177,12 +177,12 @@ func calculateDistance(firstPoint *LatLong, secondPoint *LatLong) float64 {
 		math.Pow(math.Sin(diffLon/2), 2)
 
 	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
-	return c * earthRaidusKm
+	return c * earthRadiusKm
 }
 
 func calculatePolarAngle(firstPoint *LatLong, secondPoint *LatLong) float64 {
-	distance := calculateDistance(firstPoint, secondPoint)
-	if distance < minimumDistance {
+	distanceInKm := calculateDistance(firstPoint, secondPoint)
+	if distanceInKm < minimumDistanceInKM {
 		return zero
 	}
 	lat1 := degreesToRadians(firstPoint.lat)

--- a/api/pkg/transformer/symbol/registry.go
+++ b/api/pkg/transformer/symbol/registry.go
@@ -3,6 +3,7 @@ package symbol
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/gojek/merlin/pkg/transformer/spec"
 	"github.com/gojek/merlin/pkg/transformer/symbol/function"
 	"github.com/gojek/merlin/pkg/transformer/types"
+	"github.com/gojek/merlin/pkg/transformer/types/converter"
 	"github.com/gojek/merlin/pkg/transformer/types/series"
 )
 
@@ -123,6 +125,100 @@ func (sr Registry) S2ID(latitude interface{}, longitude interface{}, level int) 
 	}
 
 	return result
+}
+
+// HaversineDistance of two points (latitude, longitude)
+// latitude and longitude can be:
+// - Json path string
+// - Slice / gota.Series
+// - float64 value
+func (sr Registry) HaversineDistance(latitude1 interface{}, longitude1 interface{}, latitude2 interface{}, longitude2 interface{}) interface{} {
+	lat1, err := sr.evalArg(latitude1)
+	if err != nil {
+		panic(err)
+	}
+
+	lon1, err := sr.evalArg(longitude1)
+	if err != nil {
+		panic(err)
+	}
+
+	lat2, err := sr.evalArg(latitude2)
+	if err != nil {
+		panic(err)
+	}
+
+	lon2, err := sr.evalArg(longitude2)
+	if err != nil {
+		panic(err)
+	}
+	result, err := function.HaversineDistance(lat1, lon1, lat2, lon2)
+	if err != nil {
+		panic(err)
+	}
+
+	return result
+}
+
+// PolarAngle calculate polar angle of two locations given latitude1, longitude1, latitude1, latitude2
+// latitude and longitude can be:
+// - Json path string
+// - Slice / gota.Series
+// - float64 value
+func (sr Registry) PolarAngle(latitude1 interface{}, longitude1 interface{}, latitude2 interface{}, longitude2 interface{}) interface{} {
+	lat1, err := sr.evalArg(latitude1)
+	if err != nil {
+		panic(err)
+	}
+
+	lon1, err := sr.evalArg(longitude1)
+	if err != nil {
+		panic(err)
+	}
+
+	lat2, err := sr.evalArg(latitude2)
+	if err != nil {
+		panic(err)
+	}
+
+	lon2, err := sr.evalArg(longitude2)
+	if err != nil {
+		panic(err)
+	}
+	result, err := function.PolarAngle(lat1, lon1, lat2, lon2)
+	if err != nil {
+		panic(err)
+	}
+
+	return result
+}
+
+// ParseTimeStamp convert timestamp value into time
+func (sr Registry) ParseTimestamp(timestamp interface{}) interface{} {
+	ts, err := sr.evalArg(timestamp)
+	if err != nil {
+		panic(err)
+	}
+	timestampVals := reflect.ValueOf(ts)
+	switch timestampVals.Kind() {
+	case reflect.Slice:
+		var values []interface{}
+		for idx := 0; idx < timestampVals.Len(); idx++ {
+			val := timestampVals.Index(idx)
+			tsInt64, err := converter.ToInt64(val.Interface())
+			if err != nil {
+				panic(err)
+			}
+			values = append(values, time.Unix(tsInt64, 0))
+		}
+		return values
+	default:
+		tsInt64, err := converter.ToInt64(ts)
+		if err != nil {
+			panic(err)
+		}
+		return time.Unix(tsInt64, 0)
+	}
 }
 
 // Now() returns current local time

--- a/api/pkg/transformer/symbol/registry.go
+++ b/api/pkg/transformer/symbol/registry.go
@@ -209,7 +209,7 @@ func (sr Registry) ParseTimestamp(timestamp interface{}) interface{} {
 			if err != nil {
 				panic(err)
 			}
-			values = append(values, time.Unix(tsInt64, 0))
+			values = append(values, time.Unix(tsInt64, 0).UTC())
 		}
 		return values
 	default:
@@ -217,7 +217,7 @@ func (sr Registry) ParseTimestamp(timestamp interface{}) interface{} {
 		if err != nil {
 			panic(err)
 		}
-		return time.Unix(tsInt64, 0)
+		return time.Unix(tsInt64, 0).UTC()
 	}
 }
 

--- a/api/pkg/transformer/symbol/registry_test.go
+++ b/api/pkg/transformer/symbol/registry_test.go
@@ -684,8 +684,8 @@ func TestSymbolRegistry_PolarAngle(t *testing.T) {
 			requestJSON: []byte(`{
 				"latitude1": -6.2446,
 				"longitude1": 106.8006,
-				"latitude2": -6.24444,
-				"longitude2": 106.79980
+				"latitude2": -6.2446,
+				"longitude2": 106.8006
 			}`),
 			args: arguments{
 				lat1: "$.latitude1",

--- a/api/pkg/transformer/symbol/registry_test.go
+++ b/api/pkg/transformer/symbol/registry_test.go
@@ -680,6 +680,22 @@ func TestSymbolRegistry_PolarAngle(t *testing.T) {
 			expectedValue: -2.2302696433651628,
 		},
 		{
+			desc: "Using single value jsonpath from request - expected 0 if distance less than 1 km",
+			requestJSON: []byte(`{
+				"latitude1": -6.2446,
+				"longitude1": 106.8006,
+				"latitude2": -6.24444,
+				"longitude2": 106.79980
+			}`),
+			args: arguments{
+				lat1: "$.latitude1",
+				lon1: "$.longitude1",
+				lat2: "$.latitude2",
+				lon2: "$.longitude2",
+			},
+			expectedValue: float64(0),
+		},
+		{
 			desc: "Using literal value from request",
 			args: arguments{
 				lat1: -6.2446,

--- a/api/pkg/transformer/symbol/registry_test.go
+++ b/api/pkg/transformer/symbol/registry_test.go
@@ -821,12 +821,12 @@ func TestSymbolRegistry_ParseTimestamp(t *testing.T) {
 		{
 			desc:          "Using literal value (int64) for timestamp",
 			timestamp:     1619541221,
-			expectedValue: time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+			expectedValue: time.Date(2021, 4, 27, 16, 33, 41, 0, time.UTC),
 		},
 		{
 			desc:          "Using literal value (string) for timestamp",
 			timestamp:     "1619541221",
-			expectedValue: time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+			expectedValue: time.Date(2021, 4, 27, 16, 33, 41, 0, time.UTC),
 		},
 		{
 			desc:      "Using single value request jsonPath for timestamp",
@@ -834,7 +834,7 @@ func TestSymbolRegistry_ParseTimestamp(t *testing.T) {
 			requestJSON: []byte(`{
 				"timestamp": 1619541221
 			}`),
-			expectedValue: time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+			expectedValue: time.Date(2021, 4, 27, 16, 33, 41, 0, time.UTC),
 		},
 		{
 			desc:      "Using single value response jsonPath for timestamp",
@@ -842,7 +842,7 @@ func TestSymbolRegistry_ParseTimestamp(t *testing.T) {
 			responseJSON: []byte(`{
 				"timestamp": 1619541221
 			}`),
-			expectedValue: time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+			expectedValue: time.Date(2021, 4, 27, 16, 33, 41, 0, time.UTC),
 		},
 		{
 			desc:      "Using array from request jsonpath for timestamp",
@@ -851,8 +851,8 @@ func TestSymbolRegistry_ParseTimestamp(t *testing.T) {
 				"timestamps": [1619541221, 1619498021]
 			}`),
 			expectedValue: []interface{}{
-				time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
-				time.Date(2021, 4, 27, 11, 33, 41, 0, time.Local),
+				time.Date(2021, 4, 27, 16, 33, 41, 0, time.UTC),
+				time.Date(2021, 4, 27, 4, 33, 41, 0, time.UTC),
 			},
 		},
 		{
@@ -862,16 +862,16 @@ func TestSymbolRegistry_ParseTimestamp(t *testing.T) {
 				"timestamps": [1619541221, "1619498021"]
 			}`),
 			expectedValue: []interface{}{
-				time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
-				time.Date(2021, 4, 27, 11, 33, 41, 0, time.Local),
+				time.Date(2021, 4, 27, 16, 33, 41, 0, time.UTC),
+				time.Date(2021, 4, 27, 4, 33, 41, 0, time.UTC),
 			},
 		},
 		{
 			desc:      "Using series",
 			timestamp: series.New([]interface{}{1619541221, 1619498021}, series.Int, "timestamp"),
 			expectedValue: []interface{}{
-				time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
-				time.Date(2021, 4, 27, 11, 33, 41, 0, time.Local),
+				time.Date(2021, 4, 27, 16, 33, 41, 0, time.UTC),
+				time.Date(2021, 4, 27, 4, 33, 41, 0, time.UTC),
 			},
 		},
 	}

--- a/api/pkg/transformer/symbol/registry_test.go
+++ b/api/pkg/transformer/symbol/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/mmcloughlin/geohash"
 	"github.com/stretchr/testify/assert"
@@ -483,6 +484,429 @@ func TestSymbolRegistry_JsonExtract(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSymbolRegistry_HaversineDistance(t *testing.T) {
+
+	type arguments struct {
+		lat1 interface{}
+		lon1 interface{}
+		lat2 interface{}
+		lon2 interface{}
+	}
+	testCases := []struct {
+		desc          string
+		requestJSON   []byte
+		responseJSON  []byte
+		args          arguments
+		expectedValue interface{}
+		err           error
+	}{
+		{
+			desc: "Using single value jsonpath from request",
+			requestJSON: []byte(`{
+				"latitude1": -6.2446,
+				"longitude1": 106.8006,
+				"latitude2": -6.2655,
+				"longitude2": 106.7843
+			}`),
+			args: arguments{
+				lat1: "$.latitude1",
+				lon1: "$.longitude1",
+				lat2: "$.latitude2",
+				lon2: "$.longitude2",
+			},
+			expectedValue: 2.9405665374312218,
+		},
+		{
+			desc: "Using literal value from request",
+			args: arguments{
+				lat1: -6.2446,
+				lon1: 106.8006,
+				lat2: -6.2655,
+				lon2: 106.7843,
+			},
+			expectedValue: 2.9405665374312218,
+		},
+		{
+			desc: "Using multiple value jsonpath from request",
+			requestJSON: []byte(`{
+				"first_points": [
+					{
+						"latitude": -6.2446,
+						"longitude": 106.8006
+					},
+					{
+						"latitude": -6.3053,
+						"longitude": 106.6435
+					}
+				],
+				"second_points": [
+					{
+						"latitude": -6.2655,
+						"longitude": 106.7843
+					},
+					{
+						"latitude": -6.2856,
+						"longitude": 106.7280
+					}
+				]
+			}`),
+			args: arguments{
+				lat1: "$.first_points[*].latitude",
+				lon1: "$.first_points[*].longitude",
+				lat2: "$.second_points[*].latitude",
+				lon2: "$.second_points[*].longitude",
+			},
+			expectedValue: []interface{}{
+				2.9405665374312218,
+				9.592767304287772,
+			},
+		},
+		{
+			desc: "Using series",
+			args: arguments{
+				lat1: series.New([]interface{}{-6.2446, -6.3053}, series.Float, "latitude"),
+				lon1: series.New([]interface{}{106.8006, 106.6435}, series.Float, "longitude"),
+				lat2: series.New([]interface{}{-6.2655, -6.2856}, series.Float, "latitude"),
+				lon2: series.New([]interface{}{106.7843, 106.7280}, series.Float, "longitude"),
+			},
+			expectedValue: []interface{}{
+				2.9405665374312218,
+				9.592767304287772,
+			},
+		},
+		{
+			desc: "Error when first point (lat1, lon1) and second points (lat2, lon2) has different type",
+			requestJSON: []byte(`{
+				"latitude1": -6.2446,
+				"longitude1": 106.8006,
+				"second_points": [
+					{
+						"latitude": -6.2655,
+						"longitude": 106.7843
+					}
+				]
+			}`),
+			args: arguments{
+				lat1: "$.latitude1",
+				lon1: "$.longitude1",
+				lat2: "$.second_points[*].latitude",
+				lon2: "$.second_points[*].longitude",
+			},
+			err: errors.New("first point and second point has different format"),
+		},
+		{
+			desc: "Error when first points and second points has different length",
+			requestJSON: []byte(`{
+				"first_points": [
+					{
+						"latitude": -6.2446,
+						"longitude": 106.8006
+					}
+				],
+				"second_points": [
+					{
+						"latitude": -6.2655,
+						"longitude": 106.7843
+					},
+					{
+						"latitude": -6.2856,
+						"longitude": 106.7280
+					}
+				]
+			}`),
+			args: arguments{
+				lat1: "$.first_points[*].latitude",
+				lon1: "$.first_points[*].longitude",
+				lat2: "$.second_points[*].latitude",
+				lon2: "$.second_points[*].longitude",
+			},
+			err: errors.New("both first point and second point arrays must have the same length"),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			sr := NewRegistryWithCompiledJSONPath(jsonpath.NewStorage())
+			requestJSONObj, responseJSONObj := createTestJSONObjects(tC.requestJSON, tC.responseJSON)
+			if requestJSONObj != nil {
+				sr.SetRawRequestJSON(requestJSONObj)
+			}
+			if responseJSONObj != nil {
+				sr.SetModelResponseJSON(responseJSONObj)
+			}
+
+			if tC.err != nil {
+				assert.PanicsWithError(t, tC.err.Error(), func() {
+					sr.HaversineDistance(tC.args.lat1, tC.args.lon1, tC.args.lat2, tC.args.lon2)
+				})
+				return
+			}
+			res := sr.HaversineDistance(tC.args.lat1, tC.args.lon1, tC.args.lat2, tC.args.lon2)
+			assert.Equal(t, tC.expectedValue, res)
+		})
+	}
+}
+
+func TestSymbolRegistry_PolarAngle(t *testing.T) {
+	type arguments struct {
+		lat1 interface{}
+		lon1 interface{}
+		lat2 interface{}
+		lon2 interface{}
+	}
+	testCases := []struct {
+		desc          string
+		requestJSON   []byte
+		responseJSON  []byte
+		args          arguments
+		expectedValue interface{}
+		err           error
+	}{
+		{
+			desc: "Using single value jsonpath from request",
+			requestJSON: []byte(`{
+				"latitude1": -6.2446,
+				"longitude1": 106.8006,
+				"latitude2": -6.2655,
+				"longitude2": 106.7843
+			}`),
+			args: arguments{
+				lat1: "$.latitude1",
+				lon1: "$.longitude1",
+				lat2: "$.latitude2",
+				lon2: "$.longitude2",
+			},
+			expectedValue: -2.2302696433651628,
+		},
+		{
+			desc: "Using literal value from request",
+			args: arguments{
+				lat1: -6.2446,
+				lon1: 106.8006,
+				lat2: -6.2655,
+				lon2: 106.7843,
+			},
+			expectedValue: -2.2302696433651628,
+		},
+		{
+			desc: "Using multiple value jsonpath from request",
+			requestJSON: []byte(`{
+				"first_points": [
+					{
+						"latitude": -6.2446,
+						"longitude": 106.8006
+					},
+					{
+						"latitude": -6.3053,
+						"longitude": 106.6435
+					}
+				],
+				"second_points": [
+					{
+						"latitude": -6.2655,
+						"longitude": 106.7843
+					},
+					{
+						"latitude": -6.2856,
+						"longitude": 106.7280
+					}
+				]
+			}`),
+			args: arguments{
+				lat1: "$.first_points[*].latitude",
+				lon1: "$.first_points[*].longitude",
+				lat2: "$.second_points[*].latitude",
+				lon2: "$.second_points[*].longitude",
+			},
+			expectedValue: []interface{}{
+				-2.2302696433651628,
+				0.2303859540944421,
+			},
+		},
+		{
+			desc: "Using series",
+			args: arguments{
+				lat1: series.New([]interface{}{-6.2446, -6.3053}, series.Float, "latitude"),
+				lon1: series.New([]interface{}{106.8006, 106.6435}, series.Float, "longitude"),
+				lat2: series.New([]interface{}{-6.2655, -6.2856}, series.Float, "latitude"),
+				lon2: series.New([]interface{}{106.7843, 106.7280}, series.Float, "longitude"),
+			},
+			expectedValue: []interface{}{
+				-2.2302696433651628,
+				0.2303859540944421,
+			},
+		},
+		{
+			desc: "Error when first point (lat1, lon1) and second points (lat2, lon2) has different type",
+			requestJSON: []byte(`{
+				"latitude1": -6.2446,
+				"longitude1": 106.8006,
+				"second_points": [
+					{
+						"latitude": -6.2655,
+						"longitude": 106.7843
+					}
+				]
+			}`),
+			args: arguments{
+				lat1: "$.latitude1",
+				lon1: "$.longitude1",
+				lat2: "$.second_points[*].latitude",
+				lon2: "$.second_points[*].longitude",
+			},
+			err: errors.New("first point and second point has different format"),
+		},
+		{
+			desc: "Error when first points and second points has different length",
+			requestJSON: []byte(`{
+				"first_points": [
+					{
+						"latitude": -6.2446,
+						"longitude": 106.8006
+					}
+				],
+				"second_points": [
+					{
+						"latitude": -6.2655,
+						"longitude": 106.7843
+					},
+					{
+						"latitude": -6.2856,
+						"longitude": 106.7280
+					}
+				]
+			}`),
+			args: arguments{
+				lat1: "$.first_points[*].latitude",
+				lon1: "$.first_points[*].longitude",
+				lat2: "$.second_points[*].latitude",
+				lon2: "$.second_points[*].longitude",
+			},
+			err: errors.New("both first point and second point arrays must have the same length"),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			sr := NewRegistryWithCompiledJSONPath(jsonpath.NewStorage())
+			requestJSONObj, responseJSONObj := createTestJSONObjects(tC.requestJSON, tC.responseJSON)
+			if requestJSONObj != nil {
+				sr.SetRawRequestJSON(requestJSONObj)
+			}
+			if responseJSONObj != nil {
+				sr.SetModelResponseJSON(responseJSONObj)
+			}
+
+			if tC.err != nil {
+				assert.PanicsWithError(t, tC.err.Error(), func() {
+					sr.HaversineDistance(tC.args.lat1, tC.args.lon1, tC.args.lat2, tC.args.lon2)
+				})
+				return
+			}
+			res := sr.PolarAngle(tC.args.lat1, tC.args.lon1, tC.args.lat2, tC.args.lon2)
+			assert.Equal(t, tC.expectedValue, res)
+		})
+	}
+}
+
+func TestSymbolRegistry_ParseTimestamp(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		timestamp     interface{}
+		requestJSON   []byte
+		responseJSON  []byte
+		expectedValue interface{}
+		err           error
+	}{
+		{
+			desc:          "Using literal value (int64) for timestamp",
+			timestamp:     1619541221,
+			expectedValue: time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+		},
+		{
+			desc:          "Using literal value (string) for timestamp",
+			timestamp:     "1619541221",
+			expectedValue: time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+		},
+		{
+			desc:      "Using single value request jsonPath for timestamp",
+			timestamp: "$.timestamp",
+			requestJSON: []byte(`{
+				"timestamp": 1619541221
+			}`),
+			expectedValue: time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+		},
+		{
+			desc:      "Using single value response jsonPath for timestamp",
+			timestamp: "$.model_response.timestamp",
+			responseJSON: []byte(`{
+				"timestamp": 1619541221
+			}`),
+			expectedValue: time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+		},
+		{
+			desc:      "Using array from request jsonpath for timestamp",
+			timestamp: "$.timestamps[*]",
+			requestJSON: []byte(`{
+				"timestamps": [1619541221, 1619498021]
+			}`),
+			expectedValue: []interface{}{
+				time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+				time.Date(2021, 4, 27, 11, 33, 41, 0, time.Local),
+			},
+		},
+		{
+			desc:      "Using array from request jsonpath for timestamp - different type",
+			timestamp: "$.timestamps[*]",
+			requestJSON: []byte(`{
+				"timestamps": [1619541221, "1619498021"]
+			}`),
+			expectedValue: []interface{}{
+				time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+				time.Date(2021, 4, 27, 11, 33, 41, 0, time.Local),
+			},
+		},
+		{
+			desc:      "Using series",
+			timestamp: series.New([]interface{}{1619541221, 1619498021}, series.Int, "timestamp"),
+			expectedValue: []interface{}{
+				time.Date(2021, 4, 27, 23, 33, 41, 0, time.Local),
+				time.Date(2021, 4, 27, 11, 33, 41, 0, time.Local),
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			sr := NewRegistryWithCompiledJSONPath(jsonpath.NewStorage())
+
+			requestJSONObj, responseJSONObj := createTestJSONObjects(tC.requestJSON, tC.responseJSON)
+			if requestJSONObj != nil {
+				sr.SetRawRequestJSON(requestJSONObj)
+			}
+			if responseJSONObj != nil {
+				sr.SetModelResponseJSON(responseJSONObj)
+			}
+
+			got := sr.ParseTimestamp(tC.timestamp)
+			assert.Equal(t, tC.expectedValue, got)
+		})
+	}
+}
+
+func createTestJSONObjects(requestJSON, responseJSON []byte) (types.JSONObject, types.JSONObject) {
+	var requestJSONObject types.JSONObject
+	if requestJSON != nil {
+		if err := json.Unmarshal(requestJSON, &requestJSONObject); err != nil {
+			panic(err)
+		}
+	}
+	var responseJSONObject types.JSONObject
+	if responseJSON != nil {
+		if err := json.Unmarshal(responseJSON, &responseJSONObject); err != nil {
+			panic(err)
+		}
+	}
+	return requestJSONObject, responseJSONObject
 }
 
 func getTestJSONObjects() (types.JSONObject, types.JSONObject) {

--- a/api/pkg/transformer/types/converter/converter.go
+++ b/api/pkg/transformer/types/converter/converter.go
@@ -32,6 +32,29 @@ func ToInt(v interface{}) (int, error) {
 	}
 }
 
+func ToInt64(v interface{}) (int64, error) {
+	switch v := v.(type) {
+	case float64:
+		return int64(v), nil
+	case float32:
+		return int64(v), nil
+	case int:
+		return int64(v), nil
+	case int8:
+		return int64(v), nil
+	case int16:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int64:
+		return int64(v), nil
+	case string:
+		return strconv.ParseInt(v, 10, 64)
+	default:
+		return 0, fmt.Errorf("unsupported conversion from %T to int", v)
+	}
+}
+
 func ToFloat64(v interface{}) (float64, error) {
 	switch v := v.(type) {
 	case float64:

--- a/api/pkg/transformer/types/converter/converter_test.go
+++ b/api/pkg/transformer/types/converter/converter_test.go
@@ -254,6 +254,110 @@ func TestToInt(t *testing.T) {
 	}
 }
 
+func TestToInt64(t *testing.T) {
+	type args struct {
+		v interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "from float64",
+			args: args{
+				v: float64(1111.111),
+			},
+			want:    1111,
+			wantErr: false,
+		},
+		{
+			name: "from float32",
+			args: args{
+				v: float32(1111.111),
+			},
+			want:    1111,
+			wantErr: false,
+		},
+		{
+			name: "from int",
+			args: args{
+				v: int(1111),
+			},
+			want:    1111,
+			wantErr: false,
+		},
+		{
+			name: "from int8",
+			args: args{
+				v: int8(11),
+			},
+			want:    11,
+			wantErr: false,
+		},
+		{
+			name: "from int16",
+			args: args{
+				v: int16(1111),
+			},
+			want:    1111,
+			wantErr: false,
+		},
+		{
+			name: "from int32",
+			args: args{
+				v: int32(111111),
+			},
+			want:    111111,
+			wantErr: false,
+		},
+		{
+			name: "from int64",
+			args: args{
+				v: int64(111111),
+			},
+			want:    111111,
+			wantErr: false,
+		},
+		{
+			name: "from string",
+			args: args{
+				v: "9223372036854775807",
+			},
+			want:    9223372036854775807,
+			wantErr: false,
+		},
+		{
+			name: "from invalid string",
+			args: args{
+				v: "hello",
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "from bool",
+			args: args{
+				v: true,
+			},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToInt(tt.args.v)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
 func TestToString(t *testing.T) {
 	type args struct {
 		v interface{}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Add built-in function that can be used for standard transformer. Below are the functions:
* HaversineDistance
* PolarAngle
* ParseTimestamp
In this PR, we will compact the json string of standard transformer config, so it will use less space
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
