### PR TITLE
Fix Error in SDK When Trying to Fetch VersionEndpoint

### DIFF
--- a/api/models/logger.go
+++ b/api/models/logger.go
@@ -56,11 +56,10 @@ type LoggerConfig struct {
 	Mode    LoggerMode `json:"mode"`
 }
 
-func (lc *LoggerConfig) ToValidConfig() *LoggerConfig {
+func (lc *LoggerConfig) SanitizeMode() {
 	if !lc.Mode.isValid() {
 		lc.Mode = LogAll
 	}
-	return lc
 }
 
 func ToKFServingLoggerMode(mode LoggerMode) kfsv1alpha2.LoggerMode {

--- a/api/models/logger.go
+++ b/api/models/logger.go
@@ -36,6 +36,15 @@ const (
 	LogResponse LoggerMode = "response"
 )
 
+func (l LoggerMode) isValid() bool {
+	switch l {
+	case LogAll, LogRequest, LogResponse:
+		return true
+	default:
+		return false
+	}
+}
+
 type Logger struct {
 	DestinationURL string        `json:"-"`
 	Model          *LoggerConfig `json:"model"`
@@ -45,6 +54,13 @@ type Logger struct {
 type LoggerConfig struct {
 	Enabled bool       `json:"enabled"`
 	Mode    LoggerMode `json:"mode"`
+}
+
+func (lc *LoggerConfig) ToValidConfig() *LoggerConfig {
+	if !lc.Mode.isValid() {
+		lc.Mode = LogAll
+	}
+	return lc
 }
 
 func ToKFServingLoggerMode(mode LoggerMode) kfsv1alpha2.LoggerMode {

--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -119,6 +119,14 @@ func (k *endpointService) DeployEndpoint(environment *models.Environment, model 
 	if newEndpoint.Logger != nil {
 		endpoint.Logger = newEndpoint.Logger
 		endpoint.Logger.DestinationURL = k.loggerDestinationURL
+		modelLogger := endpoint.Logger.Model
+		if modelLogger != nil {
+			endpoint.Logger.Model = modelLogger.ToValidConfig()
+		}
+		transformerLogger := endpoint.Logger.Transformer
+		if transformerLogger != nil {
+			endpoint.Logger.Transformer = transformerLogger.ToValidConfig()
+		}
 	}
 
 	// Configure environment variables for Pyfunc model

--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -121,11 +121,13 @@ func (k *endpointService) DeployEndpoint(environment *models.Environment, model 
 		endpoint.Logger.DestinationURL = k.loggerDestinationURL
 		modelLogger := endpoint.Logger.Model
 		if modelLogger != nil {
-			endpoint.Logger.Model = modelLogger.ToValidConfig()
+			modelLogger.SanitizeMode()
+			endpoint.Logger.Model = modelLogger
 		}
 		transformerLogger := endpoint.Logger.Transformer
 		if transformerLogger != nil {
-			endpoint.Logger.Transformer = transformerLogger.ToValidConfig()
+			transformerLogger.SanitizeMode()
+			endpoint.Logger.Transformer = transformerLogger
 		}
 	}
 

--- a/api/service/version_endpoint_service_test.go
+++ b/api/service/version_endpoint_service_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build unit
+
 package service
 
 import (
@@ -203,7 +205,7 @@ func TestDeployEndpoint(t *testing.T) {
 							Mode:    models.LoggerMode(""),
 						},
 						Transformer: &models.LoggerConfig{
-							Enabled: true,
+							Enabled: false,
 							Mode:    models.LoggerMode("randomString"),
 						},
 					},
@@ -222,8 +224,130 @@ func TestDeployEndpoint(t *testing.T) {
 							Mode:    models.LogAll,
 						},
 						Transformer: &models.LoggerConfig{
-							Enabled: true,
+							Enabled: false,
 							Mode:    models.LogAll,
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"success: new endpoint - only model logger",
+			args{
+				env,
+				model,
+				version,
+				&models.VersionEndpoint{
+					ResourceRequest: &models.ResourceRequest{
+						MinReplica:    2,
+						MaxReplica:    4,
+						CPURequest:    resource.MustParse("1"),
+						MemoryRequest: resource.MustParse("1Gi"),
+					},
+					Logger: &models.Logger{
+						Model: &models.LoggerConfig{
+							Enabled: true,
+							Mode:    models.LogRequest,
+						},
+					},
+				},
+				&models.VersionEndpoint{
+					ResourceRequest: &models.ResourceRequest{
+						MinReplica:    2,
+						MaxReplica:    4,
+						CPURequest:    resource.MustParse("1"),
+						MemoryRequest: resource.MustParse("1Gi"),
+					},
+					Logger: &models.Logger{
+						DestinationURL: loggerDestinationURL,
+						Model: &models.LoggerConfig{
+							Enabled: true,
+							Mode:    models.LogRequest,
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"success: new endpoint - only transformer logger",
+			args{
+				env,
+				model,
+				version,
+				&models.VersionEndpoint{
+					ResourceRequest: &models.ResourceRequest{
+						MinReplica:    2,
+						MaxReplica:    4,
+						CPURequest:    resource.MustParse("1"),
+						MemoryRequest: resource.MustParse("1Gi"),
+					},
+					Logger: &models.Logger{
+						Transformer: &models.LoggerConfig{
+							Enabled: true,
+							Mode:    models.LogResponse,
+						},
+					},
+				},
+				&models.VersionEndpoint{
+					ResourceRequest: &models.ResourceRequest{
+						MinReplica:    2,
+						MaxReplica:    4,
+						CPURequest:    resource.MustParse("1"),
+						MemoryRequest: resource.MustParse("1Gi"),
+					},
+					Logger: &models.Logger{
+						DestinationURL: loggerDestinationURL,
+						Transformer: &models.LoggerConfig{
+							Enabled: true,
+							Mode:    models.LogResponse,
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"success: new endpoint - both model and transformer specified with valid value",
+			args{
+				env,
+				model,
+				version,
+				&models.VersionEndpoint{
+					ResourceRequest: &models.ResourceRequest{
+						MinReplica:    2,
+						MaxReplica:    4,
+						CPURequest:    resource.MustParse("1"),
+						MemoryRequest: resource.MustParse("1Gi"),
+					},
+					Logger: &models.Logger{
+						Model: &models.LoggerConfig{
+							Enabled: true,
+							Mode:    models.LogRequest,
+						},
+						Transformer: &models.LoggerConfig{
+							Enabled: true,
+							Mode:    models.LogResponse,
+						},
+					},
+				},
+				&models.VersionEndpoint{
+					ResourceRequest: &models.ResourceRequest{
+						MinReplica:    2,
+						MaxReplica:    4,
+						CPURequest:    resource.MustParse("1"),
+						MemoryRequest: resource.MustParse("1Gi"),
+					},
+					Logger: &models.Logger{
+						DestinationURL: loggerDestinationURL,
+						Model: &models.LoggerConfig{
+							Enabled: true,
+							Mode:    models.LogRequest,
+						},
+						Transformer: &models.LoggerConfig{
+							Enabled: true,
+							Mode:    models.LogResponse,
 						},
 					},
 				},

--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -6,4 +6,4 @@ cloudpickle==1.2.2
 prometheus_client==0.7.1
 uvloop>=0.15.2
 orjson==2.6.8
-merlin-sdk==0.12.0
+merlin-sdk

--- a/python/sdk/merlin/logger.py
+++ b/python/sdk/merlin/logger.py
@@ -61,13 +61,20 @@ class Logger:
             return Logger()
         model_config = None
         if response.model is not None:
-            model_config = LoggerConfig(enabled=response.model.enabled, mode=cls.logger_mode_mapping_rev[response.model.mode])
+            model_config = LoggerConfig(enabled=response.model.enabled, mode=cls._get_logger_mode_from_api_response(response.model.mode))
         transformer_config = None
         if response.transformer is not None:
             transformer_config = LoggerConfig(enabled=response.transformer.enabled,
-                                              mode=cls.logger_mode_mapping_rev[response.transformer.mode])
+                                              mode=cls._get_logger_mode_from_api_response(response.transformer.mode))
 
         return Logger(model=model_config, transformer=transformer_config)
+
+    @classmethod
+    def _get_logger_mode_from_api_response(cls, mode_from_api_response):
+        mode = cls.logger_mode_mapping_rev.get(mode_from_api_response)
+        if mode is None:
+            mode = LoggerMode.ALL
+        return mode
 
 
     def to_logger_spec(self) -> Optional[client.Logger]:

--- a/python/sdk/merlin/version.py
+++ b/python/sdk/merlin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.12.0"
+VERSION = "0.12.1"

--- a/python/sdk/test/logger_test.py
+++ b/python/sdk/test/logger_test.py
@@ -26,6 +26,14 @@ def test_from_logger_response():
     assert result.model.mode == expected_result.model.mode
     assert result.transformer is None
 
+    logger_response = client.Logger(model=client.LoggerConfig(enabled=False, mode=""))
+    result = Logger.from_logger_response(logger_response)
+    expected_result = Logger(model=LoggerConfig(enabled=False, mode=LoggerMode.ALL))
+    assert result.model is not None
+    assert result.model.enabled == expected_result.model.enabled
+    assert result.model.mode == expected_result.model.mode
+    assert result.transformer is None
+
     logger_response = client.Logger(transformer=client.LoggerConfig(enabled=True, mode=client.LoggerMode.REQUEST))
     result = Logger.from_logger_response(logger_response)
     expected_result = Logger(transformer=LoggerConfig(enabled=True, mode=LoggerMode.REQUEST))

--- a/ui/src/pages/version/components/forms/components/LoggerPanel.js
+++ b/ui/src/pages/version/components/forms/components/LoggerPanel.js
@@ -80,7 +80,11 @@ export const LoggerPanel = ({ loggerConfig, onChangeHandler, errors = {} }) => {
           <EuiSuperSelect
             fullWidth
             options={loggerModeOptions}
-            valueOfSelected={loggerConfig.mode || "disabled"}
+            valueOfSelected={
+              loggerConfig.enabled
+                ? loggerConfig.mode || "disabled"
+                : "disabled"
+            }
             onChange={value => setValue(value)}
             isInvalid={!!errors.logger}
             itemLayoutAlign="top"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
With new release of merlin v0.12.0 , there is slight change payload logger that specified by ui. For when disabled the logger, the logger mode specified is empty string, which is invalid and sdk didn't handle it properly. So we create changes in API and SDK. 
API Changes:
* Return logger object with default logger mode if logger mode specified in body is invalid

SDK Changes:
* Fallback to default logger mode if logger mode from API response is invalid
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
