### PR TITLE
Fix padding when sidebar undocked

### DIFF
--- a/ui/src/PrivateLayout.scss
+++ b/ui/src/PrivateLayout.scss
@@ -1,4 +1,3 @@
 .main-component-layout {
   padding-top: 49px;
-  padding-right: 49px;
 }

--- a/ui/src/assets/scss/style.scss
+++ b/ui/src/assets/scss/style.scss
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 
+// don't stretch all the way
+@media only screen and (min-width: 960px) {
+  .euiPage {
+    max-width: 92% !important;
+  }
+}
+
+.euiBody--collapsibleNavIsDocked {
+  padding-left: 262px !important;
+}
+
 // expandable table's content
 .euiTableRowCell--isExpander {
   svg {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

When the sidebar undocked, the padding is inequal for both left and right sides due to missing CSS config.


Before:

![image](https://user-images.githubusercontent.com/8122852/119074561-76804a80-ba19-11eb-9072-c5ae0765e267.png)

After:

![image](https://user-images.githubusercontent.com/8122852/119074453-46d14280-ba19-11eb-9b41-3aac5db454fc.png)
