### PR TITLE
Set capacity of map when creating json with records format

### DIFF
--- a/api/pkg/transformer/types/table/table_converter.go
+++ b/api/pkg/transformer/types/table/table_converter.go
@@ -33,9 +33,9 @@ func tableToJsonRecordFormat(tbl *Table) (interface{}, error) {
 	dataFrame := tbl.DataFrame()
 	columns := dataFrame.Names()
 
-	var records []interface{}
+	records := make([]interface{}, 0, dataFrame.Nrow())
 	for i := 0; i < dataFrame.Nrow(); i++ {
-		rowJson := make(map[string]interface{})
+		rowJson := make(map[string]interface{}, len(columns))
 		for _, col := range columns {
 			values := columnsValues[col]
 			rowJson[col] = values[i]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
When the table that needs to be converted is huge, the latency in conversion is high. By add capacity when initialize map, it will reduce the latency and memory allocation
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
