### PR TITLE
Capture termination log as error message during pyfunc image build failure

### DIFF
--- a/api/imagebuilder/errors.go
+++ b/api/imagebuilder/errors.go
@@ -14,12 +14,22 @@
 
 package imagebuilder
 
-import "github.com/pkg/errors"
+import (
+	"fmt"
+	"github.com/pkg/errors"
+)
 
 var (
 	ErrUnableToGetImageRef  = errors.New("error checking previous image")
 	ErrUnableToGetJobStatus = errors.New("unknown pyfunc builder status")
 	ErrDeleteFailedJob      = errors.New("error deleting pyfunc builder")
-	ErrUnableToBuildImage   = errors.New("error building pyfunc image")
 	ErrTimeoutBuilImage     = errors.New("timeout building pyfunc image")
 )
+
+type ErrUnableToBuildImage struct {
+	Message string
+}
+
+func (e ErrUnableToBuildImage) Error() string {
+	return fmt.Sprintf("error building pyfunc image: %s", e)
+}

--- a/api/imagebuilder/imagebuilder.go
+++ b/api/imagebuilder/imagebuilder.go
@@ -17,6 +17,7 @@ package imagebuilder
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -123,7 +124,9 @@ func (c *imageBuilder) BuildImage(project mlp.Project, model *models.Model, vers
 		job, err = jobClient.Create(jobSpec)
 		if err != nil {
 			log.Errorf("unable to build image %s, error: %v", imageRef, err)
-			return "", ErrUnableToBuildImage
+			return "", ErrUnableToBuildImage{
+				Message: err.Error(),
+			}
 		}
 	} else {
 		if job.Status.Failed != 0 {
@@ -138,7 +141,9 @@ func (c *imageBuilder) BuildImage(project mlp.Project, model *models.Model, vers
 			job, err = jobClient.Create(jobSpec)
 			if err != nil {
 				log.Errorf("unable to build image %s, error: %v", imageRef, err)
-				return "", ErrUnableToBuildImage
+				return "", ErrUnableToBuildImage{
+					Message: err.Error(),
+				}
 			}
 		}
 	}
@@ -235,6 +240,7 @@ func (c *imageBuilder) waitJobCompleted(job *batchv1.Job) error {
 	timeout := time.After(c.config.BuildTimeoutDuration)
 	ticker := time.Tick(time.Second * tickDurationSecond)
 	jobClient := c.kubeClient.BatchV1().Jobs(c.config.BuildNamespace)
+	podClient := c.kubeClient.CoreV1().Pods(c.config.BuildNamespace)
 
 	for {
 		select {
@@ -245,15 +251,30 @@ func (c *imageBuilder) waitJobCompleted(job *batchv1.Job) error {
 			j, err := jobClient.Get(job.Name, metav1.GetOptions{})
 			if err != nil {
 				log.Errorf("unable to get job status for job %s: %v", job.Name, err)
-				return ErrUnableToBuildImage
+				return ErrUnableToBuildImage{
+					Message: err.Error(),
+				}
 			}
 
 			if j.Status.Succeeded == 1 {
 				// successfully created pod
 				return nil
 			} else if j.Status.Failed == 1 {
+				podList, err := podClient.List(metav1.ListOptions{
+					LabelSelector:       fmt.Sprintf("job-name=%s", j.Name),
+				})
+				pods := podList.Items
+				errMessage := ""
+				if err == nil && len(pods) > 0 {
+					sort.Slice(pods, func(i, j int) bool {
+						return pods[j].CreationTimestamp.Unix() > pods[i].CreationTimestamp.Unix()
+					})
+					errMessage = pods[0].Status.ContainerStatuses[0].State.Terminated.Message
+				}
 				log.Errorf("failed building pyfunc image %s: %v", job.Name, j.Status)
-				return ErrUnableToBuildImage
+				return ErrUnableToBuildImage{
+					Message: errMessage,
+				}
 			}
 		}
 	}
@@ -323,6 +344,7 @@ func (c *imageBuilder) createKanikoJobSpec(project mlp.Project, model *models.Mo
 							Resources: v1.ResourceRequirements{
 								Requests: defaultResourceRequests,
 							},
+							TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 						},
 					},
 					Volumes: []v1.Volume{
@@ -335,6 +357,7 @@ func (c *imageBuilder) createKanikoJobSpec(project mlp.Project, model *models.Mo
 							},
 						},
 					},
+
 				},
 			},
 		},

--- a/db-migrations/25_message_varchar_length.down.sql
+++ b/db-migrations/25_message_varchar_length.down.sql
@@ -1,2 +1,1 @@
-ALTER TABLE version_endpoints DROP COLUMN message;
-ALTER TABLE version_endpoints ADD COLUMN message varchar(64);
+ALTER TABLE version_endpoints ALTER COLUMN message varchar(64) USING SUBSTR(message, 1, 64);

--- a/db-migrations/25_message_varchar_length.down.sql
+++ b/db-migrations/25_message_varchar_length.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE version_endpoints DROP COLUMN message;
+ALTER TABLE version_endpoints ADD COLUMN message varchar(64);

--- a/db-migrations/25_message_varchar_length.up.sql
+++ b/db-migrations/25_message_varchar_length.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE version_endpoints ALTER COLUMN message varchar(2048);

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -59,6 +59,26 @@ V1 = "v1"
 PREDICTION_JOB = "PredictionJob"
 
 
+class ModelEndpointDeploymentError(Exception):
+
+    def __init__(self, model_name: str, version: int, details: str):
+        self._model_name = model_name
+        self._version = version
+        self._details = details
+
+    @property
+    def model_name(self):
+        return self._model_name
+
+    @property
+    def version(self):
+        return self._version
+
+    @property
+    def details(self):
+        return self._details
+
+
 @autostr
 class Project:
     def __init__(self, project: client.Project, mlp_url: str,
@@ -1004,10 +1024,7 @@ class ModelVersion:
         bar.stop()
 
         if endpoint.status != "running":
-            print("Model deployment failed. Reason:")
-            print(endpoint.message)
-            raise ValueError(
-                f"Failed deploying model {model.name} version {self.id}")
+            raise ModelEndpointDeploymentError(model.name, self.id, endpoint.message)
 
         log_url = f"{self.url}/{self.id}/endpoints/{endpoint.id}/logs"
         print(f"Model {model.name} version {self.id} is deployed."

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1004,6 +1004,8 @@ class ModelVersion:
         bar.stop()
 
         if endpoint.status != "running":
+            print("Model deployment failed. Reason:")
+            print(endpoint.message)
             raise ValueError(
                 f"Failed deploying model {model.name} version {self.id}")
 

--- a/python/sdk/merlin/version.py
+++ b/python/sdk/merlin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.12.1"
+VERSION = "0.12.2"

--- a/ui/src/version/VersionListTable.js
+++ b/ui/src/version/VersionListTable.js
@@ -214,7 +214,7 @@ const VersionListTable = ({
                               size={defaultIconSize}
                               color="danger"
                             />
-                            {versionEndpoint.message}
+                            Model deployment failed
                           </EuiText>
                         ) : versionEndpoint.url ? (
                           <EuiCopy


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
Currently, user has no visibility on what went wrong when deploying model endpoint. Ideally, the SDK itself should give information on what went wrong with the deployment.

One of the possible error that a user might encounter is failure to build the pyfunc image. To capture the error, we can use the logs prior to pod termination as termination message, and propagate the information back to the users. 

<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Model endpoint deployment will provide more descriptive log in the event of pyfunc image build failure.
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
