### PR TITLE
Fix transformer table UI

### DIFF
--- a/ui/src/pages/version/components/forms/components/transformer/InputPanel.js
+++ b/ui/src/pages/version/components/forms/components/transformer/InputPanel.js
@@ -75,6 +75,7 @@ export const InputPanel = ({ inputs = [], onChangeHandler, errors = {} }) => {
                         <Fragment key={`input-${idx}-table-${tableIdx}`}>
                           <TableInputCard
                             index={idx}
+                            tableIdx={tableIdx}
                             table={table}
                             onChangeHandler={onChange(
                               `${idx}.tables.${tableIdx}`

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_inputs/TableInputCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_inputs/TableInputCard.js
@@ -20,6 +20,7 @@ import { get } from "@gojek/mlp-ui";
 
 export const TableInputCard = ({
   index = 0,
+  tableIdx = 0,
   table,
   onChangeHandler,
   onColumnChangeHandler,
@@ -80,7 +81,7 @@ export const TableInputCard = ({
             <EuiFlexGroup>
               <EuiFlexItem grow={false}>
                 <EuiRadio
-                  id={`table-input-none-${index}`}
+                  id={`table-input-none-${index}-${tableIdx}`}
                   label="None"
                   checked={table.baseTable === undefined}
                   onChange={() => {
@@ -90,26 +91,26 @@ export const TableInputCard = ({
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiRadio
-                  id={`table-input-fromTable-${index}`}
+                  id={`table-input-fromTable-${index}-${tableIdx}`}
                   label="From Table"
                   checked={
                     (table.baseTable && !!table.baseTable.fromTable) || false
                   }
-                  onChange={() => {
-                    onChange("baseTable", { fromTable: new FromTable() });
-                  }}
+                  onChange={() =>
+                    onChange("baseTable", { fromTable: new FromTable() })
+                  }
                 />
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiRadio
-                  id={`table-input-fromJson-${index}`}
+                  id={`table-input-fromJson-${index}-${tableIdx}`}
                   label="From JSON"
                   checked={
                     (table.baseTable && !!table.baseTable.fromJson) || false
                   }
-                  onChange={() => {
-                    onChange("baseTable", { fromJson: new FromJson() });
-                  }}
+                  onChange={() =>
+                    onChange("baseTable", { fromJson: new FromJson() })
+                  }
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/ui/src/services/transformer/TransformerConfig.js
+++ b/ui/src/services/transformer/TransformerConfig.js
@@ -161,6 +161,35 @@ export class Pipeline {
             });
         });
 
+      input.tables &&
+        input.tables.forEach(table => {
+          console.log(table);
+          table.columns &&
+            table.columns.forEach(column => {
+              if (column.fromJson) {
+                column["type"] = "jsonpath";
+                column["value"] = column.fromJson.jsonPath;
+              } else if (column.expression) {
+                column["type"] = "expression";
+                column["value"] = column.expression;
+              } else if (column.literal) {
+                if (column.literal.stringValue) {
+                  column["type"] = "string";
+                  column["value"] = column.literal.stringValue;
+                } else if (column.literal.intValue) {
+                  column["type"] = "int";
+                  column["value"] = parseInt(column.literal.intValue);
+                } else if (column.literal.floatValue) {
+                  column["type"] = "float";
+                  column["value"] = parseFloat(column.literal.floatValue);
+                } else if (column.literal.boolValue !== undefined) {
+                  column["type"] = "bool";
+                  column["value"] = column.literal.boolValue.toString();
+                }
+              }
+            });
+        });
+
       input.variables &&
         input.variables.forEach(variable => {
           if (variable.jsonPath !== undefined && variable.jsonPath !== "") {

--- a/ui/src/services/transformer/TransformerConfig.js
+++ b/ui/src/services/transformer/TransformerConfig.js
@@ -163,7 +163,6 @@ export class Pipeline {
 
       input.tables &&
         input.tables.forEach(table => {
-          console.log(table);
           table.columns &&
             table.columns.forEach(column => {
               if (column.fromJson) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Fix some bugs on Transformer Table inputs. See below.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

1. Fix missing data on parsing Table Input's Columns when exporting from Transformer Specification YAML.

Given following transformer config:

```
...
        - tables:
          - name: customer_order
            columns:
              - name: service_area_id
                fromJson:
                  jsonPath: $.service_area_id
              - name: order_details
                expression: Geohash("$.drivers[*].driver_location.latitude", "$.drivers[*].driver_location.longitude", 7)
              - name: string
                literal:
                  stringValue: string
              - name: int
                literal:
                  intValue: 12
              - name: float
                literal:
                  floatValue: 3.14
              - name: bool
                literal:
                  boolValue: true
```

Actual result:
![image](https://user-images.githubusercontent.com/8122852/122703159-26481280-d27b-11eb-999a-fe0bbb34f0de.png)

Expected result (fixed on this PR):
![image](https://user-images.githubusercontent.com/8122852/122703179-2f38e400-d27b-11eb-9bfd-8db62cd5ff87.png)

2. Fix changing base table on Table Input

Due to the incorrect ID value on the Base Table Radio button, changing the others Tables Input on the same Table Input Group will change the first Table Input. See the video below:

https://user-images.githubusercontent.com/8122852/122703647-45936f80-d27c-11eb-9f7c-438c363c8ba1.mov

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Tested locally
