### PR TITLE
Deduplicate Entities Rows Before Sending to Feast Server

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/antonmedv/expr v1.8.9
 	github.com/buger/jsonparser v1.1.1
+	github.com/cespare/xxhash v1.1.0
 	github.com/coocood/freecache v1.1.1
 	github.com/feast-dev/feast/sdk/go v0.9.2
 	github.com/ghodss/yaml v1.0.0

--- a/api/pkg/transformer/feast/feature_retriever_test.go
+++ b/api/pkg/transformer/feast/feature_retriever_test.go
@@ -951,6 +951,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 					StatusMonitoringEnabled:          true,
 					ValueMonitoringEnabled:           true,
 					BatchSize:                        100,
+					FeastClientHystrixCommandName:    "TestFeatureRetriever_RetrieveFeatureOfEntityInRequest",
 					FeastClientMaxConcurrentRequests: 2,
 				},
 				nil,
@@ -2244,11 +2245,13 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest_BatchingCache(t *test
 				entityExtractor,
 				tt.fields.featureTableSpecs,
 				&Options{
-					StatusMonitoringEnabled: true,
-					ValueMonitoringEnabled:  true,
-					BatchSize:               1,
-					CacheEnabled:            true,
-					CacheTTL:                60 * time.Second,
+					StatusMonitoringEnabled:          true,
+					ValueMonitoringEnabled:           true,
+					BatchSize:                        1,
+					CacheEnabled:                     true,
+					CacheTTL:                         60 * time.Second,
+					FeastClientHystrixCommandName:    "TestFeatureRetriever_RetrieveFeatureOfEntityInRequest_BatchingCache",
+					FeastClientMaxConcurrentRequests: 100,
 				},
 				mockCache,
 				logger,
@@ -2823,8 +2826,9 @@ func TestFeatureRetriever_buildEntitiesRows(t *testing.T) {
 				entityExtractor,
 				featureTableSpecs,
 				&Options{
-					StatusMonitoringEnabled: true,
-					ValueMonitoringEnabled:  true,
+					StatusMonitoringEnabled:       true,
+					ValueMonitoringEnabled:        true,
+					FeastClientHystrixCommandName: "TestFeatureRetriever_buildEntitiesRows",
 				},
 				nil,
 				logger,
@@ -3068,8 +3072,9 @@ func Benchmark_buildEntitiesRequest_geohashArrays(b *testing.B) {
 		entityExtractor,
 		featureTableSpecs,
 		&Options{
-			StatusMonitoringEnabled: true,
-			ValueMonitoringEnabled:  true,
+			StatusMonitoringEnabled:       true,
+			ValueMonitoringEnabled:        true,
+			FeastClientHystrixCommandName: "Benchmark_buildEntitiesRequest_geohashArrays",
 		},
 		nil,
 		logger,
@@ -3158,6 +3163,7 @@ func TestFeatureRetriever_RetriesRetrieveFeatures_MaxConcurrent(t *testing.T) {
 	options := &Options{
 		BatchSize: 100,
 
+		FeastClientHystrixCommandName:    "TestFeatureRetriever_RetriesRetrieveFeatures_MaxConcurrent",
 		FeastClientMaxConcurrentRequests: 2,
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Dedup entity rows before sending to feast. The purpose is to remove duplicate result in feast response and reduce number of unnecessary request to feast
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
