### PR TITLE
Fix spec feast validator for case of using expression in entity extraction

### DIFF
--- a/api/cmd/transformer/main.go
+++ b/api/cmd/transformer/main.go
@@ -127,7 +127,7 @@ func initFeastTransformer(appCfg AppConfig,
 		return nil, err
 	}
 
-	compiledExpressions, err := feast.CompileExpressions(transformerConfig.TransformerConfig.Feast)
+	compiledExpressions, err := feast.CompileExpressions(transformerConfig.TransformerConfig.Feast, symbol.NewRegistry())
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/transformer/feast/compiler.go
+++ b/api/pkg/transformer/feast/compiler.go
@@ -30,14 +30,14 @@ func CompileJSONPaths(featureTableSpecs []*spec.FeatureTable) (map[string]*jsonp
 	return compiledJsonPath, nil
 }
 
-func CompileExpressions(featureTableSpecs []*spec.FeatureTable) (map[string]*vm.Program, error) {
+func CompileExpressions(featureTableSpecs []*spec.FeatureTable, symbolRegistry symbol.Registry) (map[string]*vm.Program, error) {
 	compiledExpression := make(map[string]*vm.Program)
 	for _, ft := range featureTableSpecs {
 		for _, configEntity := range ft.Entities {
 			switch configEntity.Extractor.(type) {
 			case *spec.Entity_Udf, *spec.Entity_Expression:
 				expressionExtractor := getExpressionExtractor(configEntity)
-				c, err := expr.Compile(expressionExtractor, expr.Env(symbol.NewRegistry()), expr.AllowUndefinedVariables())
+				c, err := expr.Compile(expressionExtractor, expr.Env(symbolRegistry))
 				if err != nil {
 					return nil, err
 				}

--- a/api/pkg/transformer/feast/feature_retriever_test.go
+++ b/api/pkg/transformer/feast/feature_retriever_test.go
@@ -934,7 +934,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 				panic(err)
 			}
 
-			compiledExpressions, err := CompileExpressions(tt.fields.featureTableSpecs)
+			compiledExpressions, err := CompileExpressions(tt.fields.featureTableSpecs, symbol.NewRegistry())
 			if err != nil {
 				panic(err)
 			}
@@ -2231,7 +2231,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest_BatchingCache(t *test
 				panic(err)
 			}
 
-			compiledExpressions, err := CompileExpressions(tt.fields.featureTableSpecs)
+			compiledExpressions, err := CompileExpressions(tt.fields.featureTableSpecs, symbol.NewRegistry())
 			if err != nil {
 				panic(err)
 			}
@@ -2812,7 +2812,7 @@ func TestFeatureRetriever_buildEntitiesRows(t *testing.T) {
 				panic(err)
 			}
 
-			compiledExpressions, err := CompileExpressions(featureTableSpecs)
+			compiledExpressions, err := CompileExpressions(featureTableSpecs, symbol.NewRegistry())
 			if err != nil {
 				panic(err)
 			}
@@ -3058,7 +3058,7 @@ func Benchmark_buildEntitiesRequest_geohashArrays(b *testing.B) {
 		panic(err)
 	}
 
-	compiledExpressions, err := CompileExpressions(featureTableSpecs)
+	compiledExpressions, err := CompileExpressions(featureTableSpecs, symbol.NewRegistry())
 	if err != nil {
 		panic(err)
 	}
@@ -3151,7 +3151,7 @@ func TestFeatureRetriever_RetriesRetrieveFeatures_MaxConcurrent(t *testing.T) {
 	compiledJSONPaths, err := CompileJSONPaths(defaultFeatureTableSpecs)
 	assert.NoError(t, err)
 
-	compiledExpressions, err := CompileExpressions(defaultFeatureTableSpecs)
+	compiledExpressions, err := CompileExpressions(defaultFeatureTableSpecs, symbol.NewRegistry())
 	assert.NoError(t, err)
 
 	jsonPathStorage := jsonpath.NewStorage()

--- a/api/pkg/transformer/feast/validator.go
+++ b/api/pkg/transformer/feast/validator.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ValidateTransformerConfig validate transformer config by checking the presence of entity and features in feast core
-func ValidateTransformerConfig(ctx context.Context, coreClient core.CoreServiceClient, featureTableConfigs []*spec.FeatureTable) error {
+func ValidateTransformerConfig(ctx context.Context, coreClient core.CoreServiceClient, featureTableConfigs []*spec.FeatureTable, symbolRegistry symbol.Registry) error {
 	// for each feature retrieval table
 	for _, config := range featureTableConfigs {
 		if len(config.Entities) == 0 {
@@ -64,7 +64,7 @@ func ValidateTransformerConfig(ctx context.Context, coreClient core.CoreServiceC
 				}
 			case *spec.Entity_Udf, *spec.Entity_Expression:
 				expressionExtractor := getExpressionExtractor(entity)
-				_, err = expr.Compile(expressionExtractor, expr.Env(symbol.NewRegistryWithCompiledJSONPath(nil)))
+				_, err = expr.Compile(expressionExtractor, expr.Env(symbolRegistry))
 				if err != nil {
 					return fmt.Errorf("udf compilation failed: %v", err)
 				}

--- a/api/pkg/transformer/feast/validator_test.go
+++ b/api/pkg/transformer/feast/validator_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gojek/merlin/pkg/transformer/feast/mocks"
 	"github.com/gojek/merlin/pkg/transformer/spec"
+	"github.com/gojek/merlin/pkg/transformer/symbol"
 )
 
 func TestValidateTransformerConfig(t *testing.T) {
@@ -622,7 +623,7 @@ func TestValidateTransformerConfig(t *testing.T) {
 				mockClient.On("ListFeatures", mock.Anything, mock.Anything).Return(fr, nil)
 			}
 
-			err := ValidateTransformerConfig(context.Background(), mockClient, test.trfConfig.TransformerConfig.Feast)
+			err := ValidateTransformerConfig(context.Background(), mockClient, test.trfConfig.TransformerConfig.Feast, symbol.NewRegistry())
 			if test.wantError != nil {
 				assert.EqualError(t, err, test.wantError.Error())
 				return

--- a/api/pkg/transformer/pipeline/compiler.go
+++ b/api/pkg/transformer/pipeline/compiler.go
@@ -169,7 +169,7 @@ func (c *Compiler) parseFeastSpec(featureTableSpecs []*spec.FeatureTable, compil
 	}
 	compiledJsonPaths.AddAll(jsonPaths)
 
-	expressions, err := feast.CompileExpressions(featureTableSpecs)
+	expressions, err := feast.CompileExpressions(featureTableSpecs, c.sr)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/transformer/pipeline/compiler_test.go
+++ b/api/pkg/transformer/pipeline/compiler_test.go
@@ -311,6 +311,7 @@ func TestCompiler_Compile(t *testing.T) {
 				expressions: []string{
 					"customer_level",
 					"customer_id",
+					"Now().Hour()",
 				},
 				jsonPaths: []string{
 					"$.customer.id",

--- a/api/pkg/transformer/pipeline/compiler_test.go
+++ b/api/pkg/transformer/pipeline/compiler_test.go
@@ -259,6 +259,77 @@ func TestCompiler_Compile(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "feast preprocess",
+			fields: fields{
+				sr:          symbol.NewRegistry(),
+				feastClient: &mocks.Client{},
+				feastOptions: &feast.Options{
+					CacheEnabled: true,
+				},
+				cacheOptions: &cache.Options{
+					SizeInMB: 100,
+				},
+				logger: logger,
+			},
+			specYamlFilePath: "./testdata/valid_feast_preprocess.yaml",
+			want: want{
+				expressions: []string{
+					"customer_id",
+				},
+				jsonPaths: []string{
+					"$.customer.id",
+					"$.drivers[*]",
+					"$.drivers[*].id",
+				},
+				preprocessOps: []Op{
+					&VariableDeclarationOp{},
+					&CreateTableOp{},
+					&FeastOp{},
+					&TableTransformOp{},
+					&TableJoinOp{},
+					&TableTransformOp{},
+					&JsonOutputOp{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "feast with expression",
+			fields: fields{
+				sr:          symbol.NewRegistry(),
+				feastClient: &mocks.Client{},
+				feastOptions: &feast.Options{
+					CacheEnabled: true,
+				},
+				cacheOptions: &cache.Options{
+					SizeInMB: 100,
+				},
+				logger: logger,
+			},
+			specYamlFilePath: "./testdata/valid_feast_expression.yaml",
+			want: want{
+				expressions: []string{
+					"customer_level",
+					"customer_id",
+				},
+				jsonPaths: []string{
+					"$.customer.id",
+					"$.drivers[*]",
+					"$.drivers[*].id",
+				},
+				preprocessOps: []Op{
+					&VariableDeclarationOp{},
+					&CreateTableOp{},
+					&FeastOp{},
+					&TableTransformOp{},
+					&TableJoinOp{},
+					&TableTransformOp{},
+					&JsonOutputOp{},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "preprocess - postprocess input and output - invalid",
 			fields: fields{
 				sr:          symbol.NewRegistry(),

--- a/api/pkg/transformer/pipeline/testdata/valid_feast_expression.yaml
+++ b/api/pkg/transformer/pipeline/testdata/valid_feast_expression.yaml
@@ -36,6 +36,9 @@ transformerConfig:
               - name: customer_level
                 valueType: INT32
                 expression: customer_level
+              - name: hour_of_day
+                valueType: INT32
+                expression: Now().Hour()
             features:
               - name: customer_feature_1
                 valueType: INT64

--- a/api/pkg/transformer/pipeline/testdata/valid_feast_expression.yaml
+++ b/api/pkg/transformer/pipeline/testdata/valid_feast_expression.yaml
@@ -1,0 +1,79 @@
+transformerConfig:
+  preprocess:
+    inputs:
+      - variables:
+          - name: customer_id
+            jsonPath: $.customer.id
+          - name: customer_level
+            literal:
+              intValue: 10
+      - tables:
+          - name: driver_table
+            baseTable:
+              fromJson:
+                jsonPath: $.drivers[*]
+                addRowNumber: true
+      - feast:
+          - tableName: driver_feature_table
+            project: default
+            entities:
+              - name: driver_id
+                valueType: STRING
+                jsonPath: $.drivers[*].id
+            features:
+              - name: driver_feature_1
+                valueType: INT64
+                defaultValue: '0'
+              - name: driver_feature_2
+                valueType: INT64
+                defaultValue: '0'
+          - tableName: customer_feature_table
+            project: default
+            entities:
+              - name: customer_id
+                valueType: STRING
+                expression: customer_id
+              - name: customer_level
+                valueType: INT32
+                expression: customer_level
+            features:
+              - name: customer_feature_1
+                valueType: INT64
+                defaultValue: '0'
+    transformations:
+      - tableTransformation:
+          inputTable: driver_table
+          outputTable: driver_table
+          steps:
+            - sort:
+                - column: "row_number"
+                  order: DESC
+            - renameColumns:
+                row_number: rank
+                id: driver_id
+            - updateColumns:
+                - column: customer_id
+                  expression: customer_id
+            - selectColumns: ["customer_id", "driver_id" ,"name", "rank"]
+      - tableJoin:
+          leftTable: driver_table
+          rightTable: driver_feature_table
+          outputTable: result_table
+          how: LEFT
+          onColumn: driver_id
+      - tableTransformation:
+          inputTable: result_table
+          outputTable: result_table
+          steps:
+            - sort:
+                - column: "rank"
+                  order: ASC
+            - selectColumns: [ "rank", "driver_id", "customer_id", "driver_feature_1", "driver_feature_2" ]
+    outputs:
+      - jsonOutput:
+          jsonTemplate:
+            fields:
+              - fieldName: instances
+                fromTable:
+                  tableName: result_table
+                  format: "SPLIT"

--- a/api/pkg/transformer/pipeline/validator.go
+++ b/api/pkg/transformer/pipeline/validator.go
@@ -19,6 +19,9 @@ func ValidateTransformerConfig(ctx context.Context, coreClient core.CoreServiceC
 	// compile pipeline
 	compiler := NewCompiler(symbol.NewRegistry(), nil, &feast.Options{}, &cache.Options{}, nil)
 	_, err := compiler.Compile(transformerConfig)
+	if err != nil {
+		return err
+	}
 
 	// validate all feast features in preprocess input
 	err = validateFeastFeaturesInPipeline(ctx, coreClient, transformerConfig.TransformerConfig.Preprocess, compiler.sr)
@@ -27,12 +30,7 @@ func ValidateTransformerConfig(ctx context.Context, coreClient core.CoreServiceC
 	}
 
 	// validate all feast features in post process input
-	err = validateFeastFeaturesInPipeline(ctx, coreClient, transformerConfig.TransformerConfig.Postprocess, compiler.sr)
-	if err != nil {
-		return err
-	}
-
-	return err
+	return validateFeastFeaturesInPipeline(ctx, coreClient, transformerConfig.TransformerConfig.Postprocess, compiler.sr)
 }
 
 func validateFeastFeaturesInPipeline(ctx context.Context, coreClient core.CoreServiceClient, pipeline *spec.Pipeline, symbolRegistry symbol.Registry) error {

--- a/api/pkg/transformer/pipeline/validator_test.go
+++ b/api/pkg/transformer/pipeline/validator_test.go
@@ -34,7 +34,7 @@ func TestValidateTransformerConfig(t *testing.T) {
 		expError              error
 	}{
 		{
-			name: "succuss: valid legacy feast enricher spec",
+			name: "success: valid legacy feast enricher spec",
 			args: args{
 				ctx:        context.Background(),
 				coreClient: &mocks.CoreServiceClient{},
@@ -215,6 +215,97 @@ func TestValidateTransformerConfig(t *testing.T) {
 						{
 							Spec: &core.EntitySpecV2{
 								Name:      "customer_id",
+								ValueType: types.ValueType_STRING,
+							},
+						},
+					},
+				},
+				listFeaturesResponses: []*core.ListFeaturesResponse{
+					{
+						Features: map[string]*core.FeatureSpecV2{
+							"customer_feature_table:total_booking": &core.FeatureSpecV2{
+								Name:      "total_booking",
+								ValueType: types.ValueType_INT32,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success: valid spec with feast expression",
+			args: args{
+				ctx:        context.Background(),
+				coreClient: &mocks.CoreServiceClient{},
+				transformerConfig: &spec.StandardTransformerConfig{
+					TransformerConfig: &spec.TransformerConfig{
+						Preprocess: &spec.Pipeline{
+							Inputs: []*spec.Input{
+								{
+									Variables: []*spec.Variable{
+										{
+											Name: "customer_id",
+											Value: &spec.Variable_JsonPath{
+												"$.customer_id",
+											},
+										},
+										{
+											Name: "customer_level",
+											Value: &spec.Variable_Literal{
+												Literal: &spec.Literal{
+													LiteralValue: &spec.Literal_StringValue{
+														StringValue: "1",
+													},
+												},
+											},
+										},
+									},
+									Feast: []*spec.FeatureTable{
+										{
+											Project: "merlin",
+											Entities: []*spec.Entity{
+												{
+													Name: "customer_id",
+													Extractor: &spec.Entity_Expression{
+														Expression: "customer_id",
+													},
+													ValueType: "STRING",
+												},
+												{
+													Name: "customer_level",
+													Extractor: &spec.Entity_Expression{
+														Expression: "customer_level",
+													},
+													ValueType: "STRING",
+												},
+											},
+											Features: []*spec.Feature{
+												{
+													Name:      "customer_feature_table:total_booking",
+													ValueType: "INT32",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			mockFeastCoreResponse: mockFeastCoreResponse{
+				listEntitiesResponse: &core.ListEntitiesResponse{
+					Entities: []*core.Entity{
+						{
+							Spec: &core.EntitySpecV2{
+								Name:      "customer_id",
+								ValueType: types.ValueType_STRING,
+							},
+						},
+						{
+							Spec: &core.EntitySpecV2{
+								Name:      "customer_level",
 								ValueType: types.ValueType_STRING,
 							},
 						},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Fix standard transformer spec validation for case when expression is used within feast entity extraction. E.g.
```
transformerConfig:
  preprocess:
    inputs:
      - variables:
          - name: customer_level
            literal:
              intValue: 10
      - feast:
          - tableName: customer_feature_table
            project: default
            entities:
              - name: customer_level
                valueType: INT32
                expression: customer_level
            features:
              - name: customer_feature_1
                valueType: INT64
                defaultValue: '0'
...
```
Currently, the above spec will cause validation error mentioning that `customer_level` expression is not defined even though it's declared in the variable block.
The issue is due to validator not reusing symbol registry which should contains the declared variables.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
