### PR TITLE
Add additional hystrix configuration

### DIFF
--- a/api/pkg/transformer/server/hystrix_logger.go
+++ b/api/pkg/transformer/server/hystrix_logger.go
@@ -1,0 +1,18 @@
+package server
+
+import "go.uber.org/zap"
+
+// hystrxLogger implements https://github.com/afex/hystrix-go/blob/master/hystrix/logger.go
+type hystrixLogger struct {
+	zapLogger *zap.SugaredLogger
+}
+
+// newHystrixLogger create new instance of hystrixLogger backed by zap sugared logger.
+func newHystrixLogger(zapLogger *zap.Logger) *hystrixLogger {
+	return &hystrixLogger{zapLogger: zapLogger.Sugar()}
+}
+
+// Printf will format and log the arguments as INFO log
+func (l *hystrixLogger) Printf(format string, items ...interface{}) {
+	l.zapLogger.Infof(format, items)
+}

--- a/api/pkg/transformer/server/server.go
+++ b/api/pkg/transformer/server/server.go
@@ -43,11 +43,14 @@ type Options struct {
 	HTTPServerTimeout time.Duration `envconfig:"HTTP_SERVER_TIMEOUT" default:"30s"`
 	HTTPClientTimeout time.Duration `envconfig:"HTTP_CLIENT_TIMEOUT" default:"1s"`
 
-	ModelTimeout                       time.Duration `envconfig:"MODEL_TIMEOUT" default:"1s"`
-	ModelHystrixMaxConcurrentRequests  int           `envconfig:"MODEL_HYSTRIX_MAX_CONCURRENT_REQUESTS" default:"100"`
-	ModelHystrixRetryCount             int           `envconfig:"MODEL_HYSTRIX_RETRY_COUNT" default:"0"`
-	ModelHystrixRetryBackoffInterval   time.Duration `envconfig:"MODEL_HYSTRIX_RETRY_BACKOFF_INTERVAL" default:"5ms"`
-	ModelHystrixRetryMaxJitterInterval time.Duration `envconfig:"MODEL_HYSTRIX_RETRY_MAX_JITTER_INTERVAL" default:"5ms"`
+	ModelTimeout                         time.Duration `envconfig:"MODEL_TIMEOUT" default:"1s"`
+	ModelHystrixMaxConcurrentRequests    int           `envconfig:"MODEL_HYSTRIX_MAX_CONCURRENT_REQUESTS" default:"100"`
+	ModelHystrixRetryCount               int           `envconfig:"MODEL_HYSTRIX_RETRY_COUNT" default:"0"`
+	ModelHystrixRetryBackoffInterval     time.Duration `envconfig:"MODEL_HYSTRIX_RETRY_BACKOFF_INTERVAL" default:"5ms"`
+	ModelHystrixRetryMaxJitterInterval   time.Duration `envconfig:"MODEL_HYSTRIX_RETRY_MAX_JITTER_INTERVAL" default:"5ms"`
+	ModelHystrixErrorPercentageThreshold int           `envconfig:"MODEL_HYSTRIX_ERROR_PERCENTAGE_THRESHOLD" default:"25"`
+	ModelHystrixRequestVolumeThreshold   int           `envconfig:"MODEL_HYSTRIX_REQUEST_VOLUME_THRESHOLD" default:"100"`
+	ModelHystrixSleepWindowMs            int           `envconfig:"MODEL_HYSTRIX_SLEEP_WINDOW_MS" default:"10"`
 }
 
 // Server serves various HTTP endpoints of Feast transformer.
@@ -86,6 +89,9 @@ func newHystrixClient(commandName string, o *Options) *hystrix.Client {
 		hystrix.WithHTTPTimeout(o.ModelTimeout),
 		hystrix.WithHystrixTimeout(o.ModelTimeout),
 		hystrix.WithMaxConcurrentRequests(o.ModelHystrixMaxConcurrentRequests),
+		hystrix.WithErrorPercentThreshold(o.ModelHystrixErrorPercentageThreshold),
+		hystrix.WithRequestVolumeThreshold(o.ModelHystrixRequestVolumeThreshold),
+		hystrix.WithSleepWindow(o.ModelHystrixSleepWindowMs),
 	}
 
 	if o.ModelHystrixRetryCount > 0 {

--- a/api/pkg/transformer/server/server.go
+++ b/api/pkg/transformer/server/server.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	hystrixGo "github.com/afex/hystrix-go/hystrix"
 	"github.com/gojek/heimdall/v7"
 	"github.com/gojek/heimdall/v7/httpclient"
 	"github.com/gojek/heimdall/v7/hystrix"
@@ -72,6 +73,8 @@ func New(o *Options, logger *zap.Logger) *Server {
 	if !strings.Contains(predictURL, "http://") {
 		predictURL = "http://" + predictURL
 	}
+
+	hystrixGo.SetLogger(newHystrixLogger(logger))
 
 	return &Server{
 		options:    o,

--- a/api/pkg/transformer/server/server.go
+++ b/api/pkg/transformer/server/server.go
@@ -59,7 +59,7 @@ type Server struct {
 	httpClient *hystrix.Client
 	router     *mux.Router
 	logger     *zap.Logger
-	modelUrl   string
+	modelURL   string
 
 	ContextModifier    func(ctx context.Context) context.Context
 	PreprocessHandler  func(ctx context.Context, request []byte, requestHeaders map[string]string) ([]byte, error)
@@ -76,7 +76,7 @@ func New(o *Options, logger *zap.Logger) *Server {
 	return &Server{
 		options:    o,
 		httpClient: newHystrixClient(hystrixCommandName, o),
-		modelUrl:   predictURL,
+		modelURL:   predictURL,
 		router:     mux.NewRouter(),
 		logger:     logger,
 	}
@@ -204,7 +204,7 @@ func (s *Server) predict(ctx context.Context, r *http.Request, request []byte) (
 	span, ctx := opentracing.StartSpanFromContext(ctx, "predict")
 	defer span.Finish()
 
-	req, err := http.NewRequest("POST", s.modelUrl, bytes.NewBuffer(request))
+	req, err := http.NewRequest("POST", s.modelURL, bytes.NewBuffer(request))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
This PR will add following hystrix configuration:
1. ModelHystrixErrorPercentageThreshold: causes circuits to open once the rolling measure of errors exceeds this percent of requests (default: 25)
2. ModelHystrixRequestVolumeThreshold: is the minimum number of requests needed before a circuit can be tripped due to health (default: 100)
3. ModelHystrixSleepWindowMs: is how long, in milliseconds, to wait after a circuit opens before testing for recovery (default: 10ms)

This PR also override hystrix internal logger to use our implementation to have better visibility on hystrix circuit open/close events.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
