### PR TITLE
Adding toogle to use heimdall hystrix integration

### DIFF
--- a/api/pkg/hystrix/client.go
+++ b/api/pkg/hystrix/client.go
@@ -1,7 +1,7 @@
 package hystrix
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/afex/hystrix-go/hystrix"
@@ -39,7 +39,7 @@ func (cl *Client) Do(request *http.Request) (*http.Response, error) {
 			return err
 		}
 		if response.StatusCode >= http.StatusInternalServerError {
-			return errors.New("got 5xx response code")
+			return fmt.Errorf("got 5xx response code: %d", response.StatusCode)
 		}
 		return nil
 	}, nil)

--- a/api/pkg/hystrix/client.go
+++ b/api/pkg/hystrix/client.go
@@ -1,0 +1,47 @@
+package hystrix
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/afex/hystrix-go/hystrix"
+)
+
+type Doer interface {
+	Do(request *http.Request) (*http.Response, error)
+}
+
+type Client struct {
+	client      Doer
+	commandName string
+}
+
+func NewClient(client Doer, circuitConfig *hystrix.CommandConfig, commandName string) *Client {
+	config := &hystrix.CommandConfig{}
+	if circuitConfig != nil {
+		config = circuitConfig
+	}
+
+	hystrix.ConfigureCommand(commandName, *config)
+	return &Client{
+		client:      client,
+		commandName: commandName,
+	}
+}
+
+func (cl *Client) Do(request *http.Request) (*http.Response, error) {
+	var response *http.Response
+	var err error
+
+	err = hystrix.Do(cl.commandName, func() error {
+		response, err = cl.client.Do(request)
+		if err != nil {
+			return err
+		}
+		if response.StatusCode >= http.StatusInternalServerError {
+			return errors.New("got 5xx response code")
+		}
+		return nil
+	}, nil)
+	return response, err
+}

--- a/api/pkg/hystrix/client_test.go
+++ b/api/pkg/hystrix/client_test.go
@@ -2,6 +2,7 @@ package hystrix
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -74,7 +75,7 @@ func Test_Do(t *testing.T) {
 				StatusCode: http.StatusInternalServerError,
 				Body:       ioutil.NopCloser(strings.NewReader("")),
 			},
-			wantErr: errors.New("got 5xx response code"),
+			wantErr: fmt.Errorf("got 5xx response code: %d", http.StatusInternalServerError),
 		},
 		{
 			desc: "Should error when doer failed got response",
@@ -95,6 +96,7 @@ func Test_Do(t *testing.T) {
 			resp, err := client.Do(req)
 			if tC.wantErr != nil {
 				assert.Error(t, tC.wantErr, err)
+				assert.EqualError(t, err, tC.wantErr.Error())
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tC.want, resp)

--- a/api/pkg/hystrix/client_test.go
+++ b/api/pkg/hystrix/client_test.go
@@ -1,0 +1,107 @@
+package hystrix
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type DoerFunc func(req *http.Request) (*http.Response, error)
+
+func (fun DoerFunc) Do(req *http.Request) (*http.Response, error) { return fun(req) }
+
+func Test_Do(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		doer    Doer
+		want    *http.Response
+		wantErr error
+	}{
+		{
+			desc: "Should success without body",
+			doer: DoerFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			}),
+			want: &http.Response{
+				StatusCode: http.StatusOK,
+			},
+			wantErr: nil,
+		},
+		{
+			desc: "Should success with body",
+			doer: DoerFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(strings.NewReader("")),
+				}, nil
+			}),
+			want: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(strings.NewReader("")),
+			},
+			wantErr: nil,
+		},
+		{
+			desc: "Should not return error if got 4xx status code",
+			doer: DoerFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       ioutil.NopCloser(strings.NewReader("")),
+				}, nil
+			}),
+			want: &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       ioutil.NopCloser(strings.NewReader("")),
+			},
+			wantErr: nil,
+		},
+		{
+			desc: "Should error if got 5xx status code",
+			doer: DoerFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       ioutil.NopCloser(strings.NewReader("")),
+				}, nil
+			}),
+			want: &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       ioutil.NopCloser(strings.NewReader("")),
+			},
+			wantErr: errors.New("got 5xx response code"),
+		},
+		{
+			desc: "Should error when doer failed got response",
+			doer: DoerFunc(func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("something went wrong")
+			}),
+			want:    nil,
+			wantErr: errors.New("something went wrong"),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+			require.NoError(t, err)
+			require.NotNil(t, req)
+
+			client := NewClient(tC.doer, nil, "call_api")
+			resp, err := client.Do(req)
+			if tC.wantErr != nil {
+				assert.Error(t, tC.wantErr, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tC.want, resp)
+				if resp.Body != nil {
+					assert.NoError(t, resp.Body.Close())
+				}
+			}
+		})
+	}
+}

--- a/api/pkg/transformer/server/server.go
+++ b/api/pkg/transformer/server/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 
+	hystrixpkg "github.com/gojek/merlin/pkg/hystrix"
 	"github.com/gojek/merlin/pkg/transformer/server/response"
 )
 
@@ -52,12 +53,13 @@ type Options struct {
 	ModelHystrixErrorPercentageThreshold int           `envconfig:"MODEL_HYSTRIX_ERROR_PERCENTAGE_THRESHOLD" default:"25"`
 	ModelHystrixRequestVolumeThreshold   int           `envconfig:"MODEL_HYSTRIX_REQUEST_VOLUME_THRESHOLD" default:"100"`
 	ModelHystrixSleepWindowMs            int           `envconfig:"MODEL_HYSTRIX_SLEEP_WINDOW_MS" default:"10"`
+	ModelHystrixHeimdallDisabled         bool          `envconfig:"MODEL_HYSTRIX_HEIMDALL_DISABLED" default:"true"`
 }
 
 // Server serves various HTTP endpoints of Feast transformer.
 type Server struct {
 	options    *Options
-	httpClient *hystrix.Client
+	httpClient doer
 	router     *mux.Router
 	logger     *zap.Logger
 	modelURL   string
@@ -67,6 +69,10 @@ type Server struct {
 	PostprocessHandler func(ctx context.Context, response []byte, responseHeaders map[string]string) ([]byte, error)
 }
 
+type doer interface {
+	Do(request *http.Request) (*http.Response, error)
+}
+
 // New initializes a new Server.
 func New(o *Options, logger *zap.Logger) *Server {
 	predictURL := fmt.Sprintf("%s/v1/models/%s:predict", o.ModelPredictURL, o.ModelName)
@@ -74,18 +80,38 @@ func New(o *Options, logger *zap.Logger) *Server {
 		predictURL = "http://" + predictURL
 	}
 
+	var modelHttpClient doer
 	hystrixGo.SetLogger(newHystrixLogger(logger))
+	if o.ModelHystrixHeimdallDisabled {
+		modelHttpClient = newHTTPHystrixClient(hystrixCommandName, o)
+	} else {
+		modelHttpClient = newHeimdallHystrixClient(hystrixCommandName, o)
+	}
 
 	return &Server{
 		options:    o,
-		httpClient: newHystrixClient(hystrixCommandName, o),
+		httpClient: modelHttpClient,
 		modelURL:   predictURL,
 		router:     mux.NewRouter(),
 		logger:     logger,
 	}
 }
 
-func newHystrixClient(commandName string, o *Options) *hystrix.Client {
+func newHTTPHystrixClient(commandName string, o *Options) *hystrixpkg.Client {
+	hystrixConfig := hystrixGo.CommandConfig{
+		Timeout:                int(o.ModelTimeout / time.Millisecond),
+		MaxConcurrentRequests:  o.ModelHystrixMaxConcurrentRequests,
+		RequestVolumeThreshold: o.ModelHystrixRequestVolumeThreshold,
+		SleepWindow:            o.ModelHystrixSleepWindowMs,
+		ErrorPercentThreshold:  o.ModelHystrixErrorPercentageThreshold,
+	}
+	cl := &http.Client{
+		Timeout: o.ModelTimeout,
+	}
+	return hystrixpkg.NewClient(cl, &hystrixConfig, hystrixCommandName)
+}
+
+func newHeimdallHystrixClient(commandName string, o *Options) *hystrix.Client {
 	hystrixOptions := []hystrix.Option{
 		hystrix.WithCommandName(commandName),
 		hystrix.WithHTTPClient(httpclient.NewClient(httpclient.WithHTTPTimeout(o.ModelTimeout))),

--- a/api/pkg/transformer/server/server_test.go
+++ b/api/pkg/transformer/server/server_test.go
@@ -462,7 +462,7 @@ func assertHasHeaders(t *testing.T, expected map[string]string, actual http.Head
 	return true
 }
 
-func Test_newHeimdallHystrixClient(t *testing.T) {
+func Test_newHeimdallClient(t *testing.T) {
 	defaultRequestBodyString := `{ "name": "merlin" }`
 	defaultResponseBodyString := `{ "response": "ok" }`
 
@@ -516,7 +516,7 @@ func Test_newHeimdallHystrixClient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := newHeimdallHystrixClient(tt.name, tt.args.o)
+			client := newHeimdallClient(tt.name, tt.args.o)
 			assert.NotNil(t, client)
 
 			if tt.handler != nil {
@@ -635,7 +635,7 @@ func Test_newHTTPHystrixClient(t *testing.T) {
 func Test_newHystrixClient_RetriesGetOnFailure5xx(t *testing.T) {
 	count := 0
 
-	client := newHeimdallHystrixClient("retries-on-5xx", &Options{
+	client := newHeimdallClient("retries-on-5xx", &Options{
 		ModelTimeout:                       10 * time.Millisecond,
 		ModelHystrixMaxConcurrentRequests:  100,
 		ModelHystrixRetryMaxJitterInterval: 1 * time.Millisecond,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
We face issue with additional latency by using heimdall library (hystrix integration), after did benchmark without using heimdall the latency is back to normal. Hence we add toggle to use heimdall or not. The downside by disable heimdall is there won't be any retry capability
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
