### PR TITLE
Safely delete only succeeded image building jobs

### DIFF
--- a/api/imagebuilder/janitor.go
+++ b/api/imagebuilder/janitor.go
@@ -14,12 +14,6 @@ import (
 )
 
 var (
-	failedJobs = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: "merlin_api",
-		Name:      "image_builder_failed_jobs_count",
-		Help:      "The total number of failed jobs. These jobs won't be deleted by Janitor and must be manually troubleshooted by Merlin administrators.",
-	})
-
 	deleteJobsErrors = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "merlin_api",
 		Name:      "image_builder_delete_jobs_error_count",
@@ -31,7 +25,7 @@ var (
 		Name:      "image_builder_delete_jobs_duration_ms",
 		Help:      "Image builder delete jobs histogram",
 		Buckets:   prometheus.ExponentialBuckets(64, 2, 5), // 64, 128, 256, 512, 1024, +Inf
-	}, []string{"status"})
+	}, []string{"result", "job_status"})
 )
 
 // Janitor cleans the finished image building jobs.
@@ -84,15 +78,12 @@ func (j *Janitor) getExpiredJobs() ([]batchv1.Job, error) {
 
 	now := time.Now()
 	for _, job := range jobs.Items {
-		if job.Status.Failed > 0 {
-			failedJobs.Inc()
+		if job.Status.StartTime == nil {
 			continue
 		}
 
-		if job.Status.Succeeded > 0 {
-			if now.Sub(job.Status.CompletionTime.Time) > j.cfg.Retention {
-				expiredJobs = append(expiredJobs, job)
-			}
+		if now.Sub(job.Status.StartTime.Time) > j.cfg.Retention {
+			expiredJobs = append(expiredJobs, job)
 		}
 	}
 
@@ -101,9 +92,8 @@ func (j *Janitor) getExpiredJobs() ([]batchv1.Job, error) {
 
 func (j *Janitor) deleteJobs(expiredJobs []batchv1.Job) error {
 	for _, job := range expiredJobs {
-		startTime := time.Now()
-
-		logMsg := fmt.Sprintf("Image Builder Janitor: Deleting an image builder job (%s)", job.Name)
+		jobStatusType := j.getJobStatusType(job.Status)
+		logMsg := fmt.Sprintf("Image Builder Janitor: Deleting an image builder job (Name: %s, Status: %s)", job.Name, jobStatusType)
 
 		deleteOptions := &metav1.DeleteOptions{}
 		if j.cfg.DryRun {
@@ -113,21 +103,32 @@ func (j *Janitor) deleteJobs(expiredJobs []batchv1.Job) error {
 
 		log.Debugf(logMsg)
 
+		startTime := time.Now()
 		err := j.cc.DeleteJob(j.cfg.BuildNamespace, job.Name, deleteOptions)
-		durationMs := time.Now().Sub(startTime).Milliseconds()
+		durationMs := time.Since(startTime).Microseconds()
 
 		if err != nil {
 			// Failed deletion would be picked up by the next clean up job.
 			log.Errorf("failed to delete an image builder job (%s): %s", job.Name, err)
 
 			deleteJobsErrors.Inc()
-			deleteJobsLatency.WithLabelValues("error").Observe(float64(durationMs))
+			deleteJobsLatency.WithLabelValues("error", jobStatusType).Observe(float64(durationMs))
 
 			continue
 		}
 
-		deleteJobsLatency.WithLabelValues("success").Observe(float64(durationMs))
+		deleteJobsLatency.WithLabelValues("success", jobStatusType).Observe(float64(durationMs))
 	}
 
 	return nil
+}
+
+func (j *Janitor) getJobStatusType(jobStatus batchv1.JobStatus) string {
+	if jobStatus.Active > 0 {
+		return "active"
+	}
+	if jobStatus.Succeeded > 0 {
+		return "succeeded"
+	}
+	return "failed"
 }

--- a/api/imagebuilder/janitor_test.go
+++ b/api/imagebuilder/janitor_test.go
@@ -38,7 +38,8 @@ var (
 			},
 		},
 		Status: batchv1.JobStatus{
-			Active: 1,
+			Active:    1,
+			StartTime: &now,
 		},
 	}
 
@@ -59,7 +60,8 @@ var (
 			},
 		},
 		Status: batchv1.JobStatus{
-			Failed: 1,
+			Failed:    1,
+			StartTime: &now,
 		},
 	}
 
@@ -82,6 +84,7 @@ var (
 		Status: batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &yesterday,
+			StartTime:      &yesterday,
 		},
 	}
 
@@ -104,6 +107,7 @@ var (
 		Status: batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &yesterday,
+			StartTime:      &yesterday,
 		},
 	}
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:

In the previous implementation, the Image Building Janitor simply depends on the `job.Status.CompletionTime` field which could be `nil` if the job is still active or failed. This PR avoids panic by checking the `job.Status.Succeeded` value first and only proceed with the deletion of jobs if its value is positive. I also add Prometheus metrics (`image_builder_failed_jobs_count`) to track failed jobs. For now, Janitor will do nothing upon these failed jobs and manual intervention is needed from Merlin's administrator to debug them.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #170 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
