### PR TITLE
Add recoverer on transformer

### DIFF
--- a/api/pkg/transformer/server/server.go
+++ b/api/pkg/transformer/server/server.go
@@ -305,7 +305,6 @@ func recoveryHandler(next http.Handler) http.Handler {
 		defer func() {
 			if err := recover(); err != nil {
 				debug.PrintStack()
-				w.WriteHeader(http.StatusInternalServerError)
 				response.NewError(http.StatusInternalServerError, fmt.Errorf("panic: %v", err)).Write(w)
 			}
 		}()

--- a/api/pkg/transformer/server/server.go
+++ b/api/pkg/transformer/server/server.go
@@ -306,6 +306,7 @@ func recoveryHandler(next http.Handler) http.Handler {
 			if err := recover(); err != nil {
 				debug.PrintStack()
 				w.WriteHeader(http.StatusInternalServerError)
+				response.NewError(http.StatusInternalServerError, fmt.Errorf("panic: %v", err)).Write(w)
 			}
 		}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Everytime there's panic on standard transformer, the app will just stop serving traffic. This PR adds recovered to make standard transformer more reliable.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Tested locally