### PR TITLE
Image builder: More retry if check image fail

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/antonmedv/expr v1.8.9
 	github.com/buger/jsonparser v1.1.1
+	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/cespare/xxhash v1.1.0
 	github.com/coocood/freecache v1.1.1
 	github.com/fatih/color v1.7.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -160,7 +160,10 @@ github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c h1:
 github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
 github.com/caddyserver/caddy v1.0.3/go.mod h1:G+ouvOY32gENkJC+jhgl62TyhvqEsFaDiZ4uw0RzP1E=
 github.com/casbin/casbin v1.7.0/go.mod h1:c67qKN6Oum3UF5Q1+BByfFxkwKvhwW57ITjqwtzR1KE=
+github.com/cenkalti/backoff v2.1.1+incompatible h1:tKJnvO2kl0zmb/jA5UKAt4VoEVw1qxKWjE/Bpp46npY=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
+github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-ecosystem/opencensus-go-exporter-aws v0.0.0-20180411051634-41633bc1ff6b/go.mod h1:icwlHTP1AjScKRxD/s/Qinb7mpbcoUPpqaiBvrSS/QI=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=

--- a/api/pkg/imagebuilder/imagebuilder.go
+++ b/api/pkg/imagebuilder/imagebuilder.go
@@ -222,13 +222,10 @@ func (c *imageBuilder) imageRefExists(imageName, imageTag string, retryCounter i
 				return false, nil
 			}
 
-			// If unauthorized, it's more likely due to expired token. So, let's try again
-			if terr.StatusCode == http.StatusUnauthorized {
-				if retryCounter < maxCheckImageRetry {
-					time.Sleep(1 * time.Second)
-					log.Infof("retry (%d) listing tags for %s", retryCounter+1, imageName)
-					return c.imageRefExists(imageName, imageTag, retryCounter+1)
-				}
+			if retryCounter < maxCheckImageRetry {
+				time.Sleep(1 * time.Second)
+				log.Infof("retry (%d) listing tags for %s", retryCounter+1, imageName)
+				return c.imageRefExists(imageName, imageTag, retryCounter+1)
 			}
 		} else {
 			// If it's not transport error, raise error


### PR DESCRIPTION
Refactor checking the previous image of image builder jobs using https://github.com/cenkalti/backoff.

Now we will always retry (using a backoff mechanism) regarding the error status.