### PR TITLE
Update pyfuncserver to use new mlflow version

### DIFF
--- a/python/pyfunc-server/Dockerfile
+++ b/python/pyfunc-server/Dockerfile
@@ -28,7 +28,6 @@ RUN conda env create -f ./environment.yaml && \
 
 RUN gsutil cp -r ${MODEL_URL} .
 RUN /bin/bash -c ". activate merlin-model && \
-    sed -i 's/mlflow$/mlflow==1.6.0/' /model/conda.yaml && \
     sed -i 's/pip$/pip=20.2.4/' /model/conda.yaml && \
     conda env update --name merlin-model --file /model/conda.yaml && \
     python -m pyfuncserver --model_dir /model --dry_run"

--- a/python/pyfunc-server/Pipfile
+++ b/python/pyfunc-server/Pipfile
@@ -7,4 +7,4 @@ verify_ssl = true
 pyfuncserver = {editable = true, extras = ["test"], path = "."}
 
 [requires]
-python_version = "3.7.3"
+python_version = "3.7.9"

--- a/python/pyfunc-server/pyfuncserver/model.py
+++ b/python/pyfunc-server/pyfuncserver/model.py
@@ -14,9 +14,10 @@
 
 import kfserving
 from mlflow import pyfunc
-
+from merlin.model import PYFUNC_EXTRA_ARGS_KEY, PYFUNC_MODEL_INPUT_KEY
 
 class PyFuncModel(kfserving.KFModel):  # pylint:disable=c-extension-no-member
+
     def __init__(self, name: str, artifact_dir: str):
         super().__init__(name)
         self.name = name
@@ -30,4 +31,8 @@ class PyFuncModel(kfserving.KFModel):  # pylint:disable=c-extension-no-member
         self.ready = True
 
     def predict(self, inputs: dict, **kwargs) -> dict:
-        return self._model.python_model.predict(inputs, **kwargs)
+        model_inputs = { PYFUNC_MODEL_INPUT_KEY: inputs}
+        if kwargs is not None:
+            model_inputs[PYFUNC_EXTRA_ARGS_KEY] = kwargs
+
+        return self._model.predict(model_inputs)

--- a/python/pyfunc-server/pyfuncserver/test_model.py
+++ b/python/pyfunc-server/pyfuncserver/test_model.py
@@ -26,25 +26,34 @@ import tornado.web
 from prometheus_client import Counter, Gauge
 
 from pyfuncserver import PyFuncModel
+from merlin.model import PYFUNC_EXTRA_ARGS_KEY, PYFUNC_MODEL_INPUT_KEY
 
-
-class ModelImpl(mlflow.pyfunc.PythonModel):
+class NewModelImpl(mlflow.pyfunc.PythonModel):
     def load_context(self, context):
         self.initialize(context.artifacts)
         self._use_kwargs_infer = True
 
-    def predict(self, model_inputs, **kwargs):
+    def predict(self, context, model_input):
+        extra_args = model_input.get(PYFUNC_EXTRA_ARGS_KEY, {})
+        input = model_input.get(PYFUNC_MODEL_INPUT_KEY, {})
+        if extra_args is not None and (type(extra_args) is dict):
+            return self._do_predict(input, **extra_args)
+
+        return self._do_predict(input)
+
+    def _do_predict(self, model_input, **kwargs):
         if self._use_kwargs_infer:
             try:
-                return self.infer(model_inputs, **kwargs)
+                return self.infer(model_input, **kwargs)
             except TypeError as e:
                 if "infer() got an unexpected keyword argument" in str(e):
-                    print('Fallback to the old infer() method, got TypeError exception: {}'.format(e))
+                    print(
+                        'Fallback to the old infer() method, got TypeError exception: {}'.format(e))
                     self._use_kwargs_infer = False
                 else:
                     raise e
 
-        return self.infer(model_inputs)
+        return self.infer(model_input)
 
     @abstractmethod
     def initialize(self, artifacts: dict):
@@ -70,7 +79,8 @@ class ModelImpl(mlflow.pyfunc.PythonModel):
         pass
 
 
-class EchoModel(ModelImpl):
+
+class EchoModel(NewModelImpl):
     def initialize(self, artifacts):
         self._req_count = Counter("my_req_count", "Number of incoming request")
         self._temp = Gauge("my_gauge", "Number of incoming request")
@@ -81,7 +91,7 @@ class EchoModel(ModelImpl):
         return model_input
 
 
-class HeadersModel(ModelImpl):
+class HeadersModel(NewModelImpl):
     def initialize(self, artifacts):
         pass
 
@@ -89,7 +99,7 @@ class HeadersModel(ModelImpl):
         return kwargs.get('headers', {})
 
 
-class HttpErrorModel(ModelImpl):
+class HttpErrorModel(NewModelImpl):
     def initialize(self, artifacts):
         pass
 
@@ -98,6 +108,7 @@ class HttpErrorModel(ModelImpl):
             status_code=model_input["status_code"],
             reason=model_input["reason"]
         )
+
 
 
 def test_model():

--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -6,4 +6,4 @@ cloudpickle==1.2.2
 prometheus_client==0.7.1
 uvloop>=0.15.2
 orjson==2.6.8
-merlin-sdk
+file:../sdk#egg=merlin-sdk

--- a/python/pyfunc-server/setup.py
+++ b/python/pyfunc-server/setup.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from setuptools import setup, find_packages
 
 tests_require = [
@@ -22,6 +23,15 @@ tests_require = [
 
 with open('requirements.txt') as f:
     REQUIRE = f.read().splitlines()
+
+
+# replace merlin relative path in requirements.txt into absolute path
+# setuptools could not install relative path requirements
+merlin_path = os.path.join(os.getcwd(), "../sdk")
+merlin_sdk_package = "merlin-sdk"
+for index, item in enumerate(REQUIRE):
+    if merlin_sdk_package in item:
+        REQUIRE[index] = f"{merlin_sdk_package} @ file://localhost/{merlin_path}#egg={merlin_sdk_package}"
 
 setup(
     name='pyfuncserver',

--- a/python/sdk/merlin/version.py
+++ b/python/sdk/merlin/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.14.0"
+VERSION = "0.16.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
With the recent release of mlflow sdk, there is breaking changes in our pyfunc server because we rely on internal implementation of mlflow. This PR will remove usage of internal implementation and use the API that specified by the SDK
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
