### PR TITLE
Publish charts to turing-ml Helm repository.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,3 +365,20 @@ jobs:
 #        run: ./merlin/scripts/e2e/deploy-merlin.sh "merlin/charts/merlin"
 #      - name: Run E2E test
 #        run: ./merlin/scripts/e2e/run-e2e.sh
+
+  release-charts:
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run chart-releaser
+        uses: stefanprodan/helm-gh-pages@v1.4.1
+        with:
+          token: "${{ secrets.GH_PAGES_TOKEN }}"
+          charts_url: https://turing-ml.github.io/charts
+          charts_dir: charts
+          owner: turing-ml
+          repository: charts
+          commit_username: ${{ github.actor }}
+          commit_email: "${{ github.actor }}@users.noreply.github.com"
+

--- a/charts/merlin/Chart.yaml
+++ b/charts/merlin/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Kubernetes-friendly ML model management, deployment, and serving.
 name: merlin
-version: 0.7.0
+version: 0.16.2

--- a/charts/merlin/requirements.lock
+++ b/charts/merlin/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.helm.sh/stable
   version: 7.0.0
-digest: sha256:90b2793500ca645901cfb360cb0908c71d475f9bee44adb83cb3ac1b452ffde2
-generated: "2021-03-19T20:18:42.479909+07:00"
+digest: sha256:570dd851f331533db4a76c0ba36d33a1561a20b1104d7bd84f61b26ed536a23d
+generated: "2021-10-29T11:56:03.802139+08:00"

--- a/charts/merlin/requirements.yaml
+++ b/charts/merlin/requirements.yaml
@@ -1,11 +1,11 @@
 dependencies:
   - name: postgresql
-    repository: "@stable"
+    repository: https://charts.helm.sh/stable
     version: 7.0.0
     alias: merlin-postgresql
     condition: merlin-postgresql.enabled
   - name: postgresql
-    repository: "@stable"
+    repository: https://charts.helm.sh/stable
     version: 7.0.0
     alias: mlflow-postgresql
     condition: mlflow-postgresql.enabled


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Turing requires a publicly hosted Helm chart to deploy Turing correctly. As of now, Turing depends on Merlin for getting the environments available in the cluster.

I have fixed the migration of stable repository from `@stable` to `https://charts.helm.sh/stable` as well as it will cause problems while packaging

This PR publishes the helm charts into https://turing-ml.github.io/charts/. The user would be able to install Merlin via `helm install turing/merlin`. Eventually, I would suspect that this will be moved to another repository once we have figured out where all the charts should be hosted eventually. For now this is the only repository that has been set up and due to time constraints, this should suffice.

One concern that needs to be addressed in a separate PR is that we should be publishing a public release for the Merlin container. The tagged versions are based on branch names and not built on tags.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
release public helm chart at https://turing-ml.github.io/charts/
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
