### PR TITLE
Remove default value redis and bigtable storage config

### DIFF
--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -157,7 +157,7 @@ spec:
             value: "{{ .Values.merlin.transformer.feast.defaultServingURL }}"
           - name: FEAST_SERVING_URLS
             value: {{ .Values.merlin.transformer.feast.servingURLs | toJson | quote }}
-          {{- if Values.merlin.transformer.feast.redisStorage }}
+          {{- if .Values.merlin.transformer.feast.redisStorage }}
           - name: FEAST_REDIS_CONFIG
             value: {{ .Values.merlin.transformer.feast.redisStorage | toJson | quote }}
           {{- end }}

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -157,10 +157,14 @@ spec:
             value: "{{ .Values.merlin.transformer.feast.defaultServingURL }}"
           - name: FEAST_SERVING_URLS
             value: {{ .Values.merlin.transformer.feast.servingURLs | toJson | quote }}
+          {{- if Values.merlin.transformer.feast.redisStorage }}
           - name: FEAST_REDIS_CONFIG
             value: {{ .Values.merlin.transformer.feast.redisStorage | toJson | quote }}
+          {{- end }}
+          {{- if .Values.merlin.transformer.feast.bigtableStorage }}
           - name: FEAST_BIG_TABLE_CONFIG
             value: {{ .Values.merlin.transformer.feast.bigtableStorage | toJson | quote }}
+          {{- end }}
           - name: DEFAULT_FEAST_SOURCE
             value: {{ .Values.merlin.transformer.feast.defaultFeastSource}}
           - name: FEAST_CORE_URL

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -119,17 +119,23 @@ merlin:
             icon: "bigtable",
           },
         ]
-      redisStorage:
-        serving_url: "online-serving-redis.feast.dev"
-        redis_addresses: 
-          - 10.1.1.2
-          - 10.1.1.3
-        pool_size: 5
-        max_retries: 0
-        read_timeout: "1s"
-        write_timeout: "1s"
-      bigtableStorage:
-        serving_url: "online-serving-bigtable.feast.dev"
+      ## Redis storage configuration for feast retrieval
+      ##
+      # redisStorage:
+      #   serving_url: "online-serving-redis.feast.dev"
+      #   redis_addresses: 
+      #     - 10.1.1.2
+      #     - 10.1.1.3
+      #   pool_size: 5
+      #   max_retries: 0
+      #   read_timeout: "1s"
+      #   write_timeout: "1s"
+
+      ## Bigtable storage configuration for feast retrieval
+      ##
+      # bigtableStorage:
+      #   serving_url: "online-serving-bigtable.feast.dev"
+      
       defaultFeastSource: BIGTABLE
       coreURL: core.feast.dev
       coreAuthAudience: core.feast.dev


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!
-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
In previous MR, merlin charts specify default values for redis and bigtable config. It will be problem if user only want to specify only redis or bigtable config. Hence this PR will remove default value for redis and bigtable config

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
