### PR TITLE
Fixing inifinite loading in log page

### DIFF
--- a/ui/src/components/logs/ContainerLogsView.js
+++ b/ui/src/components/logs/ContainerLogsView.js
@@ -46,6 +46,8 @@ export const ContainerLogsView = ({
     tail_lines: "1000"
   });
 
+  const [containerHaveBeenLoaded, setContainerHaveBeenLoaded] = useState(false);
+
   const [
     { data: containers, isLoaded: containersLoaded },
     getContainers
@@ -65,6 +67,9 @@ export const ContainerLogsView = ({
 
   useEffect(
     () => {
+      if (!containerHaveBeenLoaded) {
+        setContainerHaveBeenLoaded(containersLoaded);
+      }
       if (containersLoaded && params.component_type === "") {
         if (
           containers.find(
@@ -176,7 +181,9 @@ export const ContainerLogsView = ({
       </EuiTitle>
 
       <EuiPageContent>
-        {componentTypes && componentTypes.length === 0 ? (
+        {!containerHaveBeenLoaded &&
+        componentTypes &&
+        componentTypes.length === 0 ? (
           <EuiLoadingContent lines={4} />
         ) : logUrl && stackdriverUrl ? (
           <EuiFlexGroup direction="column" gutterSize="none">


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Previously logs page show infinite loading state when containers for the deployment is empty. In this PR, we only show loading state in the first API call of container list, if in the first API there is no containers for the deployment it will show 

<img width="1674" alt="Screen Shot 2021-11-29 at 07 08 29" src="https://user-images.githubusercontent.com/2369255/143792183-d2602cd9-bcb4-4733-bff2-458f8fa79092.png">

And in the background the page will call list container in specific interval, once the list of container is not empty it will show

<img width="1678" alt="Screen Shot 2021-11-29 at 07 12 30" src="https://user-images.githubusercontent.com/2369255/143792243-28dd1fc3-b352-4abd-b699-bebcb74f3bee.png">
**Which issue(s) this PR fixes**

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
