### PR TITLE
Add Go's zoneinfo to standard transformer docker image

### DIFF
--- a/api/pkg/transformer/symbol/time.go
+++ b/api/pkg/transformer/symbol/time.go
@@ -114,12 +114,12 @@ func (sr Registry) processTimestampFunction(timestamps, timezone interface{}, ti
 			panic("timezone should not be an array but single value")
 		}
 
-		tsInt64, err := converter.ToInt64(ts)
+		timeLocation, err := loadLocationCached(fmt.Sprintf("%s", tz))
 		if err != nil {
 			panic(err)
 		}
 
-		timeLocation, err := loadLocationCached(fmt.Sprintf("%s", tz))
+		tsInt64, err := converter.ToInt64(ts)
 		if err != nil {
 			panic(err)
 		}
@@ -193,7 +193,7 @@ func (sr Registry) ParseDateTime(datetime, timezone interface{}, format string) 
 			panic("timezone should not be an array but single value")
 		}
 
-		timeLocation, err := loadLocationCached(fmt.Sprintf("%v", timezone))
+		timeLocation, err := loadLocationCached(fmt.Sprintf("%v", tz))
 		if err != nil {
 			panic(err)
 		}

--- a/transformer.Dockerfile
+++ b/transformer.Dockerfile
@@ -30,8 +30,8 @@ COPY python/batch-predictor ../python/batch-predictor
 
 RUN go build -o bin/transformer \
     -ldflags="-X github.com/prometheus/common/version.Branch=${BRANCH} \
-                -X github.com/prometheus/common/version.Revision=${REVISION} \
-                -X github.com/prometheus/common/version.Version=${VERSION}" \
+    -X github.com/prometheus/common/version.Revision=${REVISION} \
+    -X github.com/prometheus/common/version.Version=${VERSION}" \
     ./cmd/transformer/main.go
 
 # ============================================================
@@ -40,5 +40,8 @@ RUN go build -o bin/transformer \
 FROM alpine:3.12
 
 COPY --from=go-builder /src/api/bin/transformer /usr/bin/transformer
+COPY --from=go-builder /usr/local/go/lib/time/zoneinfo.zip /zoneinfo.zip
+
+ENV ZONEINFO=/zoneinfo.zip
 
 ENTRYPOINT ["transformer"]


### PR DESCRIPTION
TIL that Golang needs the host machine to provide zone info. In our standard transformer Docker image, we are using Alpine and it only has a UTC timezone. Hence we need to supply zone info to our image.