### PR TITLE
Fix yaml specification on feast standard transformer page

### DIFF
--- a/ui/src/services/transformer/TransformerConfig.js
+++ b/ui/src/services/transformer/TransformerConfig.js
@@ -194,6 +194,7 @@ export class Pipeline {
               } else if (entity.jsonPath) {
                 entity["fieldType"] = "JSONPath";
                 entity["field"] = { jsonPath: entity.jsonPath };
+                delete entity["jsonPath"]; // Delete this since all jsonPath will be converted to jsonPathConfig
               } else if (entity.jsonPathConfig) {
                 entity["fieldType"] = "JSONPath";
                 entity["field"] = entity.jsonPathConfig;
@@ -234,6 +235,8 @@ export class Pipeline {
           if (variable.jsonPath !== undefined && variable.jsonPath !== "") {
             variable["type"] = "jsonpath";
             variable["value"] = { jsonPath: variable.jsonPath };
+            variable["jsonPathConfig"] = { jsonPath: variable.jsonPath };
+            delete variable["jsonPath"]; // Delete this since all jsonPath will be converted to jsonPathConfig
           } else if (variable.jsonPathConfig !== undefined) {
             variable["type"] = "jsonpath";
             variable["value"] = variable.jsonPathConfig;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Fix issue on how ui render standard transformer yaml spec when user use `jsonPath` instead of `jsonPathConfig`. The issue is happening on :
* variable declaration. Currently it showing `jsonPath` field instead of `jsonPathConfig`
* feast entity. Currently showing both `jsonPath` and `jsonPathConfig` where the expected is only `jsonPathConfig`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->
Before:
<img width="754" alt="Screen Shot 2022-01-05 at 15 32 06" src="https://user-images.githubusercontent.com/2369255/148196238-03ef5890-830f-4614-9498-ca6a22fa6529.png">

After:
<img width="1126" alt="Screen Shot 2022-01-05 at 16 38 27" src="https://user-images.githubusercontent.com/2369255/148196262-0db2b2df-170b-418c-86b2-745024964ecd.png">


```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
