### PR TITLE
Do not set resource annotation when queueResourcePercentage is empty

### DIFF
--- a/api/cluster/templater.go
+++ b/api/cluster/templater.go
@@ -67,10 +67,13 @@ func (t *KFServingResourceTemplater) CreateInferenceServiceSpec(modelService *mo
 	objectMeta := metav1.ObjectMeta{
 		Name:      modelService.Name,
 		Namespace: modelService.Namespace,
-		Annotations: map[string]string{
+		Labels:    labels,
+	}
+
+	if config.QueueResourcePercentage != "" {
+		objectMeta.Annotations = map[string]string{
 			annotationQueueProxyResource: config.QueueResourcePercentage,
-		},
-		Labels: labels,
+		}
 	}
 
 	if modelService.Type == models.ModelTypePyFunc {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Do not set queue resource annotation in inferenceservice if queueResourcePercentage is empty

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
