### PR TITLE
Initialize inference service's annotations

### DIFF
--- a/api/cluster/controller_test.go
+++ b/api/cluster/controller_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build unit
-
 package cluster
 
 import (
@@ -323,15 +321,18 @@ func TestController_DeployInferenceService(t *testing.T) {
 			modelSvc,
 			&inferenceServiceReactor{
 				nil,
-				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, svcName)},
+				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, svcName),
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     statusReady},
+					Status:     statusReady,
+				},
 				nil,
 			},
 			deployTimeout,
@@ -342,16 +343,20 @@ func TestController_DeployInferenceService(t *testing.T) {
 			modelSvc,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name}},
-				nil},
+				nil,
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     statusReady},
-				nil},
+					Status:     statusReady,
+				},
+				nil,
+			},
 			deployTimeout,
 			false,
 		},
@@ -370,15 +375,18 @@ func TestController_DeployInferenceService(t *testing.T) {
 			},
 			&inferenceServiceReactor{
 				nil,
-				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, svcName)},
+				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, svcName),
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     statusReady},
+					Status:     statusReady,
+				},
 				nil,
 			},
 			deployTimeout,
@@ -389,16 +397,20 @@ func TestController_DeployInferenceService(t *testing.T) {
 			modelSvc,
 			&inferenceServiceReactor{
 				nil,
-				errors.New("error")},
+				errors.New("error"),
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     statusReady},
-				nil},
+					Status:     statusReady,
+				},
+				nil,
+			},
 			deployTimeout,
 			true,
 		},
@@ -407,16 +419,20 @@ func TestController_DeployInferenceService(t *testing.T) {
 			modelSvc,
 			&inferenceServiceReactor{
 				nil,
-				kerrors.NewNotFound(schema.GroupResource{Group: "kubeflow.com/kfserving", Resource: "inferenceservices"}, svcName)},
+				kerrors.NewNotFound(schema.GroupResource{Group: "kubeflow.com/kfserving", Resource: "inferenceservices"}, svcName),
+			},
 			&inferenceServiceReactor{
 				nil,
-				errors.New("error creating inference service")},
+				errors.New("error creating inference service"),
+			},
 			nil,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     statusReady},
-				nil},
+					Status:     statusReady,
+				},
+				nil,
+			},
 			deployTimeout,
 			true,
 		},
@@ -425,16 +441,20 @@ func TestController_DeployInferenceService(t *testing.T) {
 			modelSvc,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				nil,
-				errors.New("error updating inference service")},
+				errors.New("error updating inference service"),
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     statusReady},
-				nil},
+					Status:     statusReady,
+				},
+				nil,
+			},
 			deployTimeout,
 			true,
 		},
@@ -443,10 +463,12 @@ func TestController_DeployInferenceService(t *testing.T) {
 			modelSvc,
 			&inferenceServiceReactor{
 				nil,
-				kerrors.NewNotFound(schema.GroupResource{Group: "kubeflow.com/kfserving", Resource: "inferenceservices"}, svcName)},
+				kerrors.NewNotFound(schema.GroupResource{Group: "kubeflow.com/kfserving", Resource: "inferenceservices"}, svcName),
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				nil,
@@ -460,16 +482,20 @@ func TestController_DeployInferenceService(t *testing.T) {
 			modelSvc,
 			&inferenceServiceReactor{
 				nil,
-				kerrors.NewNotFound(schema.GroupResource{Group: "kubeflow.com/kfserving", Resource: "inferenceservices"}, svcName)},
+				kerrors.NewNotFound(schema.GroupResource{Group: "kubeflow.com/kfserving", Resource: "inferenceservices"}, svcName),
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     createPredErrorCond()},
-				nil},
+					Status:     createPredErrorCond(),
+				},
+				nil,
+			},
 			deployTimeout,
 			true,
 		},
@@ -478,16 +504,20 @@ func TestController_DeployInferenceService(t *testing.T) {
 			modelSvc,
 			&inferenceServiceReactor{
 				nil,
-				kerrors.NewNotFound(schema.GroupResource{Group: "kubeflow.com/kfserving", Resource: "inferenceservices"}, svcName)},
+				kerrors.NewNotFound(schema.GroupResource{Group: "kubeflow.com/kfserving", Resource: "inferenceservices"}, svcName),
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     createRoutesErrorCond()},
-				nil},
+					Status:     createRoutesErrorCond(),
+				},
+				nil,
+			},
 			deployTimeout,
 			true,
 		},
@@ -496,15 +526,18 @@ func TestController_DeployInferenceService(t *testing.T) {
 			modelSvc,
 			&inferenceServiceReactor{
 				nil,
-				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, svcName)},
+				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, svcName),
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     statusReady},
+					Status:     statusReady,
+				},
 				nil,
 			},
 			1 * time.Millisecond,
@@ -525,15 +558,18 @@ func TestController_DeployInferenceService(t *testing.T) {
 			},
 			&inferenceServiceReactor{
 				nil,
-				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, svcName)},
+				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, svcName),
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     statusReady},
+					Status:     statusReady,
+				},
 				nil,
 			},
 			deployTimeout,
@@ -554,15 +590,18 @@ func TestController_DeployInferenceService(t *testing.T) {
 			},
 			&inferenceServiceReactor{
 				nil,
-				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, svcName)},
+				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, svcName),
+			},
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name}},
-				nil},
+				nil,
+			},
 			nil,
 			&inferenceServiceReactor{
 				&v1alpha2.InferenceService{
 					ObjectMeta: metav1.ObjectMeta{Name: svcName, Namespace: project.Name},
-					Status:     statusReady},
+					Status:     statusReady,
+				},
 				nil,
 			},
 			deployTimeout,
@@ -744,7 +783,8 @@ func Test_controller_ListPods(t *testing.T) {
 						},
 					},
 				},
-			}}, nil
+			},
+		}, nil
 	})
 
 	ctl := &controller{

--- a/api/cluster/templater.go
+++ b/api/cluster/templater.go
@@ -65,9 +65,10 @@ func (t *KFServingResourceTemplater) CreateInferenceServiceSpec(modelService *mo
 	labels := modelService.Metadata.ToLabel()
 
 	objectMeta := metav1.ObjectMeta{
-		Name:      modelService.Name,
-		Namespace: modelService.Namespace,
-		Labels:    labels,
+		Name:        modelService.Name,
+		Namespace:   modelService.Namespace,
+		Labels:      labels,
+		Annotations: map[string]string{},
 	}
 
 	if config.QueueResourcePercentage != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Previously, in #224, when there's no queueResourcePercentage in environment's configuration, we won't add `"queue.sidecar.serving.knative.dev/resourcePercentage"` in inference service's annotation. On doing this, we are not initializing annotation field on inference service object, leading to panic when another value expect this annotation field to be exist.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes deploying pyfunc mode without queue resource percentage.

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally