### PR TITLE
Support convertion from []interface to list type.

### DIFF
--- a/api/pkg/transformer/feast/feature_cache.go
+++ b/api/pkg/transformer/feast/feature_cache.go
@@ -145,7 +145,7 @@ func (fc *featureCache) insertFeaturesOfEntity(entity feast.Row, columnNames []s
 
 func castValueRow(row types.ValueRow, columnTypes []feastTypes.ValueType_Enum) (types.ValueRow, error) {
 	for idx, val := range row {
-		castedVal, err := castIntValue(val, columnTypes[idx])
+		castedVal, err := castValue(val, columnTypes[idx])
 		if err != nil {
 			return row, err
 		}
@@ -154,14 +154,38 @@ func castValueRow(row types.ValueRow, columnTypes []feastTypes.ValueType_Enum) (
 	return row, nil
 }
 
-// castIntValue cast cache value of integer type to its correct type
-// It's necessary since we store value as json and any integer value will be converted to float64
-func castIntValue(val interface{}, valType feastTypes.ValueType_Enum) (interface{}, error) {
+// castValue cast cache value of interface type to its correct type
+// It's necessary since we store value as json
+func castValue(val interface{}, valType feastTypes.ValueType_Enum) (interface{}, error) {
+	if val == nil {
+		return val, nil
+	}
+
 	switch valType {
-	case feastTypes.ValueType_INT64:
-		return converter.ToInt64(val)
 	case feastTypes.ValueType_INT32:
 		return converter.ToInt32(val)
+	case feastTypes.ValueType_INT64:
+		return converter.ToInt64(val)
+	case feastTypes.ValueType_FLOAT:
+		return converter.ToFloat32(val)
+	case feastTypes.ValueType_DOUBLE:
+		return converter.ToFloat64(val)
+	case feastTypes.ValueType_BOOL:
+		return converter.ToBool(val)
+	case feastTypes.ValueType_STRING:
+		return converter.ToString(val)
+	case feastTypes.ValueType_INT32_LIST:
+		return converter.ToInt32List(val)
+	case feastTypes.ValueType_INT64_LIST:
+		return converter.ToInt64List(val)
+	case feastTypes.ValueType_FLOAT_LIST:
+		return converter.ToFloat32List(val)
+	case feastTypes.ValueType_DOUBLE_LIST:
+		return converter.ToFloat64List(val)
+	case feastTypes.ValueType_BOOL_LIST:
+		return converter.ToBoolList(val)
+	case feastTypes.ValueType_STRING_LIST:
+		return converter.ToStringList(val)
 	default:
 		return val, nil
 	}

--- a/api/pkg/transformer/pipeline/testdata/valid_feast_series_transform.yaml
+++ b/api/pkg/transformer/pipeline/testdata/valid_feast_series_transform.yaml
@@ -55,9 +55,11 @@ transformerConfig:
                 valueType: STRING
                 expression: driver_customer_feature_table.Col('customers_picked_up').Flatten().Unique()
             features:
-              - name: customer_feature_1
-                valueType: INT64
-                defaultValue: "0"
+              - name: customer_name
+                valueType: STRING
+              - name: customer_phones
+                valueType: DOUBLE_LIST
+                defaultValue: "[123456, 456789]"
     transformations:
       - tableTransformation:
           inputTable: driver_table

--- a/api/pkg/transformer/types/converter/converter.go
+++ b/api/pkg/transformer/types/converter/converter.go
@@ -122,6 +122,27 @@ func ToIntList(val interface{}) ([]int, error) {
 			out[i] = d
 		}
 		return out, nil
+	case interface{}:
+		switch reflect.TypeOf(val).Kind() {
+		case reflect.Slice:
+			list := reflect.ValueOf(v)
+			l := list.Len()
+			out := make([]int, l)
+			for i := 0; i < l; i++ {
+				d, err := ToInt(list.Index(i).Interface())
+				if err != nil {
+					return nil, err
+				}
+				out[i] = d
+			}
+			return out, nil
+		default:
+			d, err := ToInt(v)
+			if err != nil {
+				return nil, err
+			}
+			return []int{d}, nil
+		}
 	default:
 		return nil, fmt.Errorf("unsupported conversion from %T to []int", v)
 	}
@@ -236,6 +257,27 @@ func ToInt32List(val interface{}) ([]int32, error) {
 			out[i] = int32(d)
 		}
 		return out, nil
+	case interface{}:
+		switch reflect.TypeOf(val).Kind() {
+		case reflect.Slice:
+			list := reflect.ValueOf(v)
+			l := list.Len()
+			out := make([]int32, l)
+			for i := 0; i < l; i++ {
+				d, err := ToInt32(list.Index(i).Interface())
+				if err != nil {
+					return nil, err
+				}
+				out[i] = d
+			}
+			return out, nil
+		default:
+			d, err := ToInt32(v)
+			if err != nil {
+				return nil, err
+			}
+			return []int32{d}, nil
+		}
 	default:
 		return nil, fmt.Errorf("unsupported conversion from %T to []int32", v)
 	}
@@ -300,6 +342,27 @@ func ToInt64List(val interface{}) ([]int64, error) {
 			out[i] = d
 		}
 		return out, nil
+	case interface{}:
+		switch reflect.TypeOf(val).Kind() {
+		case reflect.Slice:
+			list := reflect.ValueOf(v)
+			l := list.Len()
+			out := make([]int64, l)
+			for i := 0; i < l; i++ {
+				d, err := ToInt64(list.Index(i).Interface())
+				if err != nil {
+					return nil, err
+				}
+				out[i] = d
+			}
+			return out, nil
+		default:
+			d, err := ToInt64(v)
+			if err != nil {
+				return nil, err
+			}
+			return []int64{d}, nil
+		}
 	default:
 		return nil, fmt.Errorf("unsupported conversion from %T to []int64", v)
 	}
@@ -414,6 +477,27 @@ func ToFloat32List(val interface{}) ([]float32, error) {
 			out[i] = float32(d)
 		}
 		return out, nil
+	case interface{}:
+		switch reflect.TypeOf(val).Kind() {
+		case reflect.Slice:
+			list := reflect.ValueOf(v)
+			l := list.Len()
+			out := make([]float32, l)
+			for i := 0; i < l; i++ {
+				d, err := ToFloat32(list.Index(i).Interface())
+				if err != nil {
+					return nil, err
+				}
+				out[i] = d
+			}
+			return out, nil
+		default:
+			d, err := ToFloat32(v)
+			if err != nil {
+				return nil, err
+			}
+			return []float32{d}, nil
+		}
 	default:
 		return nil, fmt.Errorf("unsupported conversion from %T to []float32", v)
 	}
@@ -478,6 +562,27 @@ func ToFloat64List(val interface{}) ([]float64, error) {
 			out[i] = d
 		}
 		return out, nil
+	case interface{}:
+		switch reflect.TypeOf(val).Kind() {
+		case reflect.Slice:
+			list := reflect.ValueOf(v)
+			l := list.Len()
+			out := make([]float64, l)
+			for i := 0; i < l; i++ {
+				d, err := ToFloat64(list.Index(i).Interface())
+				if err != nil {
+					return nil, err
+				}
+				out[i] = d
+			}
+			return out, nil
+		default:
+			d, err := ToFloat64(v)
+			if err != nil {
+				return nil, err
+			}
+			return []float64{d}, nil
+		}
 	default:
 		return nil, fmt.Errorf("unsupported conversion from %T to []float64", v)
 	}
@@ -487,6 +592,22 @@ func ToBool(v interface{}) (bool, error) {
 	switch v := v.(type) {
 	case bool:
 		return v, nil
+	case int, int8, int16, int32, int64:
+		i := reflect.ValueOf(v).Int()
+		if i == 1 {
+			return true, nil
+		} else if i == 0 {
+			return false, nil
+		}
+		return false, fmt.Errorf("error parsing %v to bool", v)
+	case float32, float64:
+		i := reflect.ValueOf(v).Float()
+		if i == float64(1) {
+			return true, nil
+		} else if i == float64(0) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error parsing %v to bool", v)
 	case string:
 		return strconv.ParseBool(v)
 	default:
@@ -562,6 +683,27 @@ func ToBoolList(val interface{}) ([]bool, error) {
 			out[i] = b
 		}
 		return out, nil
+	case interface{}:
+		switch reflect.TypeOf(val).Kind() {
+		case reflect.Slice:
+			list := reflect.ValueOf(v)
+			l := list.Len()
+			out := make([]bool, l)
+			for i := 0; i < l; i++ {
+				d, err := ToBool(list.Index(i).Interface())
+				if err != nil {
+					return nil, err
+				}
+				out[i] = d
+			}
+			return out, nil
+		default:
+			d, err := ToBool(v)
+			if err != nil {
+				return nil, err
+			}
+			return []bool{d}, nil
+		}
 	default:
 		return nil, fmt.Errorf("unsupported conversion from %T to []bool", v)
 	}

--- a/api/pkg/transformer/types/converter/converter_test.go
+++ b/api/pkg/transformer/types/converter/converter_test.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"encoding/base64"
 	"reflect"
+	"strings"
 	"testing"
 
 	feast "github.com/feast-dev/feast/sdk/go"
@@ -37,12 +38,52 @@ func TestToBool(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from int",
+			args: args{
+				v: 0,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "from int",
+			args: args{
+				v: 1,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "from int",
+			args: args{
+				v: 3,
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
 			name: "from float",
 			args: args{
 				v: 1.1,
 			},
 			want:    false,
 			wantErr: true,
+		},
+		{
+			name: "from float",
+			args: args{
+				v: float64(1.0),
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "from float",
+			args: args{
+				v: float64(0.0),
+			},
+			want:    false,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -53,7 +94,119 @@ func TestToBool(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, got, tt.want)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToFloat32(t *testing.T) {
+	type args struct {
+		v interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    float32
+		wantErr bool
+	}{
+		{
+			name: "from float64",
+			args: args{
+				v: float64(11.111),
+			},
+			want:    float32(11.111),
+			wantErr: false,
+		},
+		{
+			name: "from float32",
+			args: args{
+				v: float32(11.111),
+			},
+			want:    float32(11.111),
+			wantErr: false,
+		},
+		{
+			name: "from float32",
+			args: args{
+				v: float32(11.111),
+			},
+			want:    float32(11.111),
+			wantErr: false,
+		},
+		{
+			name: "from int",
+			args: args{
+				v: int(1111),
+			},
+			want:    float32(1111),
+			wantErr: false,
+		},
+		{
+			name: "from int8",
+			args: args{
+				v: int8(111),
+			},
+			want:    float32(111),
+			wantErr: false,
+		},
+		{
+			name: "from int16",
+			args: args{
+				v: int16(11111),
+			},
+			want:    float32(11111),
+			wantErr: false,
+		},
+		{
+			name: "from int32",
+			args: args{
+				v: int32(11111),
+			},
+			want:    float32(11111),
+			wantErr: false,
+		},
+		{
+			name: "from int64",
+			args: args{
+				v: int64(11111),
+			},
+			want:    float32(11111),
+			wantErr: false,
+		},
+		{
+			name: "from string",
+			args: args{
+				v: "1111.1111",
+			},
+			want:    float32(1111.1111),
+			wantErr: false,
+		},
+		{
+			name: "from string - invalid",
+			args: args{
+				v: "asd",
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "from bool",
+			args: args{
+				v: false,
+			},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToFloat32(tt.args.v)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.InEpsilon(t, tt.want, got, 0.0001)
 		})
 	}
 }
@@ -1002,12 +1155,28 @@ func TestToIntList(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from string - invalid",
+			args: args{
+				val: "asd",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "from []string",
 			args: args{
 				val: []string{"23", "30"},
 			},
 			want:    []int{23, 30},
 			wantErr: false,
+		},
+		{
+			name: "from []string - invalid",
+			args: args{
+				val: []string{"asd", "qwe"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "from bool: true",
@@ -1032,6 +1201,22 @@ func TestToIntList(t *testing.T) {
 			},
 			want:    []int{1, 0},
 			wantErr: false,
+		},
+		{
+			name: "from []interface",
+			args: args{
+				val: []interface{}{0, 1, 10},
+			},
+			want:    []int{0, 1, 10},
+			wantErr: false,
+		},
+		{
+			name: "from []interface - invalid",
+			args: args{
+				val: []interface{}{0, 1, 10, "asd'"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -1147,12 +1332,28 @@ func TestToInt32List(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from string - invalid",
+			args: args{
+				val: "asd",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "from []string",
 			args: args{
 				val: []string{"23", "30"},
 			},
 			want:    []int32{23, 30},
 			wantErr: false,
+		},
+		{
+			name: "from []string - invalid",
+			args: args{
+				val: []string{"23", "30", "asd"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "from bool: true",
@@ -1177,6 +1378,22 @@ func TestToInt32List(t *testing.T) {
 			},
 			want:    []int32{1, 0},
 			wantErr: false,
+		},
+		{
+			name: "from []interface",
+			args: args{
+				val: []interface{}{0, 1, 10},
+			},
+			want:    []int32{0, 1, 10},
+			wantErr: false,
+		},
+		{
+			name: "from []interface - invalid",
+			args: args{
+				val: []interface{}{0, 1, 10, "asd'"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -1292,12 +1509,28 @@ func TestToInt64List(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from string - invalid",
+			args: args{
+				val: "asd",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "from []string",
 			args: args{
 				val: []string{"23", "30"},
 			},
 			want:    []int64{23, 30},
 			wantErr: false,
+		},
+		{
+			name: "from []string - invalid",
+			args: args{
+				val: []string{"23", "30", "asd"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "from bool: true",
@@ -1322,6 +1555,22 @@ func TestToInt64List(t *testing.T) {
 			},
 			want:    []int64{1, 0},
 			wantErr: false,
+		},
+		{
+			name: "from []interface",
+			args: args{
+				val: []interface{}{0, 1, 10},
+			},
+			want:    []int64{0, 1, 10},
+			wantErr: false,
+		},
+		{
+			name: "from []interface - invalid",
+			args: args{
+				val: []interface{}{0, 1, 10, "asd'"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -1437,12 +1686,28 @@ func TestToFloat32List(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from string - invalid",
+			args: args{
+				val: "asd",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "from []string",
 			args: args{
 				val: []string{"23.3", "30.09"},
 			},
 			want:    []float32{23.3, 30.09},
 			wantErr: false,
+		},
+		{
+			name: "from []string - invalid",
+			args: args{
+				val: []string{"23.3", "30.09", "asd"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "from bool: true",
@@ -1467,6 +1732,22 @@ func TestToFloat32List(t *testing.T) {
 			},
 			want:    []float32{1, 0},
 			wantErr: false,
+		},
+		{
+			name: "from []interface",
+			args: args{
+				val: []interface{}{0, 1, 10},
+			},
+			want:    []float32{0, 1, 10},
+			wantErr: false,
+		},
+		{
+			name: "from []interface - invalid",
+			args: args{
+				val: []interface{}{0, 1, 10, "asd'"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -1542,11 +1823,11 @@ func TestToFloat64List(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "from float32",
+			name: "from float64",
 			args: args{
-				val: float32(3.1415),
+				val: float64(3.14),
 			},
-			want:    []float64{3.1415},
+			want:    []float64{3.14},
 			wantErr: false,
 		},
 		{
@@ -1558,9 +1839,9 @@ func TestToFloat64List(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "from []float32",
+			name: "from []float64",
 			args: args{
-				val: []float32{float32(3.14), float32(4.56)},
+				val: []float64{float64(3.14), float64(4.56)},
 			},
 			want:    []float64{3.14, 4.56},
 			wantErr: false,
@@ -1582,12 +1863,68 @@ func TestToFloat64List(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from string - invalid",
+			args: args{
+				val: "asd",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "from []string",
 			args: args{
 				val: []string{"23.3", "30.09"},
 			},
 			want:    []float64{23.3, 30.09},
 			wantErr: false,
+		},
+		{
+			name: "from []string - invalid",
+			args: args{
+				val: []string{"23.3", "30.09", "asd"},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "from bool: true",
+			args: args{
+				val: true,
+			},
+			want:    []float64{1},
+			wantErr: false,
+		},
+		{
+			name: "from bool: false",
+			args: args{
+				val: false,
+			},
+			want:    []float64{0},
+			wantErr: false,
+		},
+		{
+			name: "from []bool",
+			args: args{
+				val: []bool{true, false},
+			},
+			want:    []float64{1, 0},
+			wantErr: false,
+		},
+		{
+			name: "from []interface",
+			args: args{
+				val: []interface{}{3.14, 1, 10},
+			},
+			want:    []float64{3.14, 1, 10},
+			wantErr: false,
+		},
+		{
+			name: "from []interface - invalid",
+			args: args{
+				val: []interface{}{3.14, 1, 10, "asd'"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -1597,6 +1934,14 @@ func TestToFloat64List(t *testing.T) {
 				t.Errorf("ToFloat64List() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
+			// for boolean case we use assert.Equal because the array contains 0 value
+			// assert.InEpsilonSlice expects all element in array to be greater than 0
+			if strings.Contains(tt.name, "bool") {
+				assert.Equal(t, tt.want, got)
+				return
+			}
+
 			assert.InEpsilonSlice(t, tt.want, got, 0.0001)
 		})
 	}
@@ -1618,6 +1963,14 @@ func TestToBoolList(t *testing.T) {
 				val: int(1),
 			},
 			want:    []bool{true},
+			wantErr: false,
+		},
+		{
+			name: "from int",
+			args: args{
+				val: int(0),
+			},
+			want:    []bool{false},
 			wantErr: false,
 		},
 		{
@@ -1653,6 +2006,14 @@ func TestToBoolList(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from []int, but neither 0 or 1",
+			args: args{
+				val: []int{int(2), int(3)},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "from []int32",
 			args: args{
 				val: []int32{int32(1), int32(0)},
@@ -1675,6 +2036,22 @@ func TestToBoolList(t *testing.T) {
 			},
 			want:    []bool{true},
 			wantErr: false,
+		},
+		{
+			name: "from float32",
+			args: args{
+				val: float32(0),
+			},
+			want:    []bool{false},
+			wantErr: false,
+		},
+		{
+			name: "from float32 - invalid",
+			args: args{
+				val: float32(100),
+			},
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "from float64",
@@ -1701,6 +2078,14 @@ func TestToBoolList(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from []float64, neither 0 or 1",
+			args: args{
+				val: []float64{float64(2), float64(3)},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "from string",
 			args: args{
 				val: "t",
@@ -1709,12 +2094,28 @@ func TestToBoolList(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from string",
+			args: args{
+				val: "benar",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "from []string",
 			args: args{
 				val: []string{"1", "t", "T", "true", "TRUE", "True"},
 			},
 			want:    []bool{true, true, true, true, true, true},
 			wantErr: false,
+		},
+		{
+			name: "from []string - invalid",
+			args: args{
+				val: []string{"1", "t", "T", "true", "TRUE", "True", "ASD"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "from bool: true",
@@ -1739,6 +2140,30 @@ func TestToBoolList(t *testing.T) {
 			},
 			want:    []bool{true, false},
 			wantErr: false,
+		},
+		{
+			name: "from []interface - valid bool",
+			args: args{
+				val: []interface{}{true},
+			},
+			want:    []bool{true},
+			wantErr: false,
+		},
+		{
+			name: "from []interface - valid bool",
+			args: args{
+				val: []interface{}{true, "true", 1, 0, "f", "FALSE"},
+			},
+			want:    []bool{true, true, true, false, false, false},
+			wantErr: false,
+		},
+		{
+			name: "from []interface - invalid",
+			args: args{
+				val: []interface{}{"QWE", "ASD"},
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Given a first successful standard transformer request that has feast feature retrieval with list types:

```
➜ curl -X POST http://localhost:8081/v1/models/echo:predict -d '{"driver_id":1}'
{"merlin":[{"merlin_test_driver_features:test_double":3.14,"merlin_test_driver_features:test_double_list":[1.23,2.34,3.45],"merlin_test_driver_features:test_int64":null,"merlin_test_driver_features:test_int64_list":null,"merlin_test_driver_features:test_string":null,"merlin_test_driver_features:test_string_list":["AAABBBCCC"],"merlin_test_driver_id":"1"}]}
```

And feast cache is enabled, and we send the same request, it will return error:

```
➜ curl -X POST http://localhost:8081/v1/models/echo:predict -d '{"driver_id":1}'
{"code":500,"message":"preprocessing error: error executing preprocessing operation: *pipeline.FeastOp: unsupported conversion from []interface {} to []float64"}
```

This is because, on the second request, standard transformer uses cached feature value which stored as []interface instead of the correct Feast's list type.

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally