### PR TITLE
Implement configurable autoscaling strategy

### DIFF
--- a/api/api/version_endpoints_api.go
+++ b/api/api/version_endpoints_api.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
+	merror "github.com/gojek/merlin/pkg/errors"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
@@ -189,6 +190,10 @@ func (c *EndpointsController) CreateEndpoint(r *http.Request, vars map[string]st
 
 	endpoint, err = c.EndpointsService.DeployEndpoint(ctx, env, model, version, newEndpoint)
 	if err != nil {
+		if errors.Is(err, merror.InvalidInputError) {
+			return BadRequest(fmt.Sprintf("Unable to deploy model version: %s", err.Error()))
+		}
+
 		return InternalServerError(fmt.Sprintf("Unable to deploy model version: %s", err.Error()))
 	}
 
@@ -263,6 +268,10 @@ func (c *EndpointsController) UpdateEndpoint(r *http.Request, vars map[string]st
 
 		endpoint, err = c.EndpointsService.DeployEndpoint(ctx, env, model, version, newEndpoint)
 		if err != nil {
+			if errors.Is(err, merror.InvalidInputError) {
+				return BadRequest(fmt.Sprintf("Unable to deploy model version: %s", err.Error()))
+			}
+
 			return InternalServerError(fmt.Sprintf("Unable to deploy model version: %s", err.Error()))
 		}
 	} else if newEndpoint.Status == models.EndpointTerminated {

--- a/api/api/version_endpoints_api_test.go
+++ b/api/api/version_endpoints_api_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/feast-dev/feast/sdk/go/protos/feast/core"
 	"github.com/feast-dev/feast/sdk/go/protos/feast/types"
+	"github.com/gojek/merlin/pkg/deployment"
 	"github.com/gojek/mlp/api/client"
 	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
@@ -3645,7 +3646,7 @@ func TestUpdateEndpoint(t *testing.T) {
 						Value: "1",
 					},
 				}),
-				DeploymentMode: models.RawDeploymentMode,
+				DeploymentMode: deployment.RawDeploymentMode,
 			},
 			modelService: func() *mocks.ModelsService {
 				svc := &mocks.ModelsService{}
@@ -3723,7 +3724,7 @@ func TestUpdateEndpoint(t *testing.T) {
 							Value: "1",
 						},
 					}),
-					DeploymentMode: models.ServerlessDeploymentMode,
+					DeploymentMode: deployment.ServerlessDeploymentMode,
 				}, nil)
 				svc.On("DeployEndpoint", context.Background(), mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&models.VersionEndpoint{
 					ID:                   uuid,
@@ -3754,7 +3755,7 @@ func TestUpdateEndpoint(t *testing.T) {
 							Value: "1",
 						},
 					}),
-					DeploymentMode: models.RawDeploymentMode,
+					DeploymentMode: deployment.RawDeploymentMode,
 					CreatedUpdated: models.CreatedUpdated{},
 				}, nil)
 				return svc
@@ -3790,7 +3791,7 @@ func TestUpdateEndpoint(t *testing.T) {
 							Value: "1",
 						},
 					}),
-					DeploymentMode: models.RawDeploymentMode,
+					DeploymentMode: deployment.RawDeploymentMode,
 					CreatedUpdated: models.CreatedUpdated{},
 				},
 			},
@@ -3823,7 +3824,7 @@ func TestUpdateEndpoint(t *testing.T) {
 						Value: "1",
 					},
 				}),
-				DeploymentMode: models.RawDeploymentMode,
+				DeploymentMode: deployment.RawDeploymentMode,
 			},
 			modelService: func() *mocks.ModelsService {
 				svc := &mocks.ModelsService{}
@@ -3901,7 +3902,7 @@ func TestUpdateEndpoint(t *testing.T) {
 							Value: "1",
 						},
 					}),
-					DeploymentMode: models.ServerlessDeploymentMode,
+					DeploymentMode: deployment.ServerlessDeploymentMode,
 				}, nil)
 				return svc
 			},

--- a/api/cluster/templater.go
+++ b/api/cluster/templater.go
@@ -429,31 +429,31 @@ func createAnnotations(modelService *models.Service, config *config.DeploymentCo
 	}
 	annotations[kserveconstant.DeploymentMode] = deployMode
 
-	if modelService.AutoscalingTarget != nil {
+	if modelService.AutoscalingPolicy != nil {
 		if modelService.DeploymentMode == deployment.RawDeploymentMode {
 			annotations[kserveconstant.AutoscalerClass] = string(kserveconstant.AutoscalerClassHPA)
-			autoscalingMetrics, err := toKServeAutoscalerMetrics(modelService.AutoscalingTarget.MetricsType)
+			autoscalingMetrics, err := toKServeAutoscalerMetrics(modelService.AutoscalingPolicy.MetricsType)
 			if err != nil {
 				return nil, err
 			}
 
 			annotations[kserveconstant.AutoscalerMetrics] = autoscalingMetrics
-			annotations[kserveconstant.TargetUtilizationPercentage] = fmt.Sprintf("%.0f", modelService.AutoscalingTarget.TargetValue)
+			annotations[kserveconstant.TargetUtilizationPercentage] = fmt.Sprintf("%.0f", modelService.AutoscalingPolicy.TargetValue)
 		} else if modelService.DeploymentMode == deployment.ServerlessDeploymentMode {
-			if modelService.AutoscalingTarget.MetricsType == autoscaling.CPUUtilization ||
-				modelService.AutoscalingTarget.MetricsType == autoscaling.MemoryUtilization {
+			if modelService.AutoscalingPolicy.MetricsType == autoscaling.CPUUtilization ||
+				modelService.AutoscalingPolicy.MetricsType == autoscaling.MemoryUtilization {
 				annotations[knautoscaling.ClassAnnotationKey] = knautoscaling.HPA
 			} else {
 				annotations[knautoscaling.ClassAnnotationKey] = knautoscaling.KPA
 			}
 
-			autoscalingMetrics, err := toKNativeAutoscalerMetrics(modelService.AutoscalingTarget.MetricsType)
+			autoscalingMetrics, err := toKNativeAutoscalerMetrics(modelService.AutoscalingPolicy.MetricsType)
 			if err != nil {
 				return nil, err
 			}
 
 			annotations[knautoscaling.MetricAnnotationKey] = autoscalingMetrics
-			annotations[knautoscaling.TargetAnnotationKey] = fmt.Sprintf("%.0f", modelService.AutoscalingTarget.TargetValue)
+			annotations[knautoscaling.TargetAnnotationKey] = fmt.Sprintf("%.0f", modelService.AutoscalingPolicy.TargetValue)
 		}
 	}
 

--- a/api/cluster/templater_test.go
+++ b/api/cluster/templater_test.go
@@ -767,7 +767,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 				Options:        &models.ModelOption{},
 				Metadata:       model.Metadata,
 				DeploymentMode: deployment.RawDeploymentMode,
-				AutoscalingTarget: &autoscaling.AutoscalingTarget{
+				AutoscalingPolicy: &autoscaling.AutoscalingPolicy{
 					MetricsType: autoscaling.CPUUtilization,
 					TargetValue: 30,
 				},
@@ -822,7 +822,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 				Options:        &models.ModelOption{},
 				Metadata:       model.Metadata,
 				DeploymentMode: deployment.RawDeploymentMode,
-				AutoscalingTarget: &autoscaling.AutoscalingTarget{
+				AutoscalingPolicy: &autoscaling.AutoscalingPolicy{
 					MetricsType: autoscaling.MemoryUtilization,
 					TargetValue: 30,
 				},
@@ -840,7 +840,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 				Options:        &models.ModelOption{},
 				Metadata:       model.Metadata,
 				DeploymentMode: deployment.ServerlessDeploymentMode,
-				AutoscalingTarget: &autoscaling.AutoscalingTarget{
+				AutoscalingPolicy: &autoscaling.AutoscalingPolicy{
 					MetricsType: autoscaling.CPUUtilization,
 					TargetValue: 30,
 				},
@@ -895,7 +895,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 				Options:        &models.ModelOption{},
 				Metadata:       model.Metadata,
 				DeploymentMode: deployment.ServerlessDeploymentMode,
-				AutoscalingTarget: &autoscaling.AutoscalingTarget{
+				AutoscalingPolicy: &autoscaling.AutoscalingPolicy{
 					MetricsType: autoscaling.MemoryUtilization,
 					TargetValue: 30,
 				},
@@ -950,7 +950,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 				Options:        &models.ModelOption{},
 				Metadata:       model.Metadata,
 				DeploymentMode: deployment.ServerlessDeploymentMode,
-				AutoscalingTarget: &autoscaling.AutoscalingTarget{
+				AutoscalingPolicy: &autoscaling.AutoscalingPolicy{
 					MetricsType: autoscaling.Concurrency,
 					TargetValue: 2,
 				},
@@ -1005,7 +1005,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 				Options:        &models.ModelOption{},
 				Metadata:       model.Metadata,
 				DeploymentMode: deployment.ServerlessDeploymentMode,
-				AutoscalingTarget: &autoscaling.AutoscalingTarget{
+				AutoscalingPolicy: &autoscaling.AutoscalingPolicy{
 					MetricsType: autoscaling.RPS,
 					TargetValue: 10,
 				},
@@ -2298,7 +2298,7 @@ func TestPatchInferenceServiceSpec(t *testing.T) {
 				Options:        &models.ModelOption{},
 				Metadata:       model.Metadata,
 				DeploymentMode: deployment.RawDeploymentMode,
-				AutoscalingTarget: &autoscaling.AutoscalingTarget{
+				AutoscalingPolicy: &autoscaling.AutoscalingPolicy{
 					MetricsType: autoscaling.CPUUtilization,
 					TargetValue: 30,
 				},
@@ -2379,7 +2379,7 @@ func TestPatchInferenceServiceSpec(t *testing.T) {
 				Options:        &models.ModelOption{},
 				Metadata:       model.Metadata,
 				DeploymentMode: deployment.ServerlessDeploymentMode,
-				AutoscalingTarget: &autoscaling.AutoscalingTarget{
+				AutoscalingPolicy: &autoscaling.AutoscalingPolicy{
 					MetricsType: autoscaling.Concurrency,
 					TargetValue: 2,
 				},

--- a/api/go.mod
+++ b/api/go.mod
@@ -69,6 +69,7 @@ require (
 	k8s.io/apimachinery v0.23.0
 	k8s.io/client-go v0.23.0
 	knative.dev/pkg v0.0.0-20211206113427-18589ac7627e
+	knative.dev/serving v0.28.0
 	sigs.k8s.io/controller-runtime v0.11.0
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -186,7 +187,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	knative.dev/networking v0.0.0-20211209101835-8ef631418fc0 // indirect
-	knative.dev/serving v0.28.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
 

--- a/api/models/resource_request.go
+++ b/api/models/resource_request.go
@@ -27,7 +27,6 @@ type ResourceRequest struct {
 	MinReplica int `json:"min_replica"`
 	// Maximum number of replica of inference service
 	MaxReplica int `json:"max_replica"`
-
 	// CPU request of inference service
 	CPURequest resource.Quantity `json:"cpu_request"`
 	// Memory request of inference service

--- a/api/models/service.go
+++ b/api/models/service.go
@@ -39,7 +39,7 @@ type Service struct {
 	AutoscalingTarget *autoscaling.AutoscalingTarget
 }
 
-func NewService(model *Model, version *Version, modelOpt *ModelOption, resource *ResourceRequest, envVars EnvVars, environment string, transformer *Transformer, logger *Logger, deploymentType deployment.Mode, autoscalingTarget *autoscaling.AutoscalingTarget) *Service {
+func NewService(model *Model, version *Version, modelOpt *ModelOption, resource *ResourceRequest, envVars EnvVars, environment string, transformer *Transformer, logger *Logger, deploymentMode deployment.Mode, autoscalingTarget *autoscaling.AutoscalingTarget) *Service {
 	return &Service{
 		Name:            CreateInferenceServiceName(model.Name, version.ID.String()),
 		Namespace:       model.Project.Name,
@@ -57,7 +57,7 @@ func NewService(model *Model, version *Version, modelOpt *ModelOption, resource 
 		},
 		Transformer:       transformer,
 		Logger:            logger,
-		DeploymentMode:    deploymentType,
+		DeploymentMode:    deploymentMode,
 		AutoscalingTarget: autoscalingTarget,
 	}
 }

--- a/api/models/service.go
+++ b/api/models/service.go
@@ -17,25 +17,29 @@ package models
 import (
 	"fmt"
 	"strings"
+
+	"github.com/gojek/merlin/pkg/autoscaling"
+	"github.com/gojek/merlin/pkg/deployment"
 )
 
 type Service struct {
-	Name            string
-	Namespace       string
-	ServiceName     string
-	URL             string
-	ArtifactURI     string
-	Type            string
-	Options         *ModelOption
-	ResourceRequest *ResourceRequest
-	EnvVars         EnvVars
-	Metadata        Metadata
-	Transformer     *Transformer
-	Logger          *Logger
-	DeploymentMode  DeploymentMode
+	Name              string
+	Namespace         string
+	ServiceName       string
+	URL               string
+	ArtifactURI       string
+	Type              string
+	Options           *ModelOption
+	ResourceRequest   *ResourceRequest
+	EnvVars           EnvVars
+	Metadata          Metadata
+	Transformer       *Transformer
+	Logger            *Logger
+	DeploymentMode    deployment.Mode
+	AutoscalingTarget *autoscaling.AutoscalingTarget
 }
 
-func NewService(model *Model, version *Version, modelOpt *ModelOption, resource *ResourceRequest, envVars EnvVars, environment string, transformer *Transformer, logger *Logger, deploymentType DeploymentMode) *Service {
+func NewService(model *Model, version *Version, modelOpt *ModelOption, resource *ResourceRequest, envVars EnvVars, environment string, transformer *Transformer, logger *Logger, deploymentType deployment.Mode, autoscalingTarget *autoscaling.AutoscalingTarget) *Service {
 	return &Service{
 		Name:            CreateInferenceServiceName(model.Name, version.ID.String()),
 		Namespace:       model.Project.Name,
@@ -51,9 +55,10 @@ func NewService(model *Model, version *Version, modelOpt *ModelOption, resource 
 			Environment: environment,
 			Labels:      model.Project.Labels,
 		},
-		Transformer:    transformer,
-		Logger:         logger,
-		DeploymentMode: deploymentType,
+		Transformer:       transformer,
+		Logger:            logger,
+		DeploymentMode:    deploymentType,
+		AutoscalingTarget: autoscalingTarget,
 	}
 }
 

--- a/api/models/service.go
+++ b/api/models/service.go
@@ -36,10 +36,10 @@ type Service struct {
 	Transformer       *Transformer
 	Logger            *Logger
 	DeploymentMode    deployment.Mode
-	AutoscalingTarget *autoscaling.AutoscalingTarget
+	AutoscalingPolicy *autoscaling.AutoscalingPolicy
 }
 
-func NewService(model *Model, version *Version, modelOpt *ModelOption, resource *ResourceRequest, envVars EnvVars, environment string, transformer *Transformer, logger *Logger, deploymentMode deployment.Mode, autoscalingTarget *autoscaling.AutoscalingTarget) *Service {
+func NewService(model *Model, version *Version, modelOpt *ModelOption, resource *ResourceRequest, envVars EnvVars, environment string, transformer *Transformer, logger *Logger, deploymentMode deployment.Mode, autoscalingPolicy *autoscaling.AutoscalingPolicy) *Service {
 	return &Service{
 		Name:            CreateInferenceServiceName(model.Name, version.ID.String()),
 		Namespace:       model.Project.Name,
@@ -58,7 +58,7 @@ func NewService(model *Model, version *Version, modelOpt *ModelOption, resource 
 		Transformer:       transformer,
 		Logger:            logger,
 		DeploymentMode:    deploymentMode,
-		AutoscalingTarget: autoscalingTarget,
+		AutoscalingPolicy: autoscalingPolicy,
 	}
 }
 

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -34,7 +34,7 @@ type VersionEndpoint struct {
 	// The field name has to be prefixed with the related struct name
 	// in order for gorm Preload to work with association_foreignkey
 	VersionID ID `json:"version_id"`
-	// VersionModelID model if from which the version endpoint is created
+	// VersionModelID model id from which the version endpoint is created
 	VersionModelID ID `json:"model_id"`
 	// Status status of the version endpoint
 	Status EndpointStatus `json:"status"`

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -69,8 +69,18 @@ type VersionEndpoint struct {
 	CreatedUpdated
 }
 
-func NewVersionEndpoint(env *Environment, project mlp.Project, model *Model, version *Version, monitoringConfig config.MonitoringConfig) *VersionEndpoint {
+func NewVersionEndpoint(env *Environment, project mlp.Project, model *Model, version *Version, monitoringConfig config.MonitoringConfig, deploymentMode deployment.Mode) *VersionEndpoint {
 	id := uuid.New()
+
+	if deploymentMode == deployment.EmptyDeploymentMode {
+		deploymentMode = deployment.ServerlessDeploymentMode
+	}
+
+	autoscalingPolicy := autoscaling.DefaultServerlessAutoscalingPolicy
+	if deploymentMode == deployment.RawDeploymentMode {
+		autoscalingPolicy = autoscaling.DefaultRawDeploymentAutoscalingPolicy
+	}
+
 	ve := &VersionEndpoint{
 		ID:                   id,
 		VersionID:            version.ID,
@@ -81,8 +91,8 @@ func NewVersionEndpoint(env *Environment, project mlp.Project, model *Model, ver
 		EnvironmentName:      env.Name,
 		Environment:          env,
 		ResourceRequest:      env.DefaultResourceRequest,
-		DeploymentMode:       deployment.ServerlessDeploymentMode,
-		AutoscalingPolicy:    autoscaling.DefaultServerlessAutoscalingPolicy,
+		DeploymentMode:       deploymentMode,
+		AutoscalingPolicy:    autoscalingPolicy,
 	}
 
 	if monitoringConfig.MonitoringEnabled {

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -64,8 +64,8 @@ type VersionEndpoint struct {
 	Logger *Logger `json:"logger,omitempty" gorm:"logger"`
 	// DeploymentMode deployment mode of the version endpoint, it can be raw_deployment or serverless
 	DeploymentMode deployment.Mode `json:"deployment_mode" gorm:"deployment_mode"`
-	// AutoscalingTarget controls the conditions when autoscaling should be triggered
-	AutoscalingTarget *autoscaling.AutoscalingTarget `json:"autoscaling_target" gorm:"autoscaling_target"`
+	// AutoscalingPolicy controls the conditions when autoscaling should be triggered
+	AutoscalingPolicy *autoscaling.AutoscalingPolicy `json:"autoscaling_policy" gorm:"autoscaling_policy"`
 	CreatedUpdated
 }
 
@@ -82,7 +82,7 @@ func NewVersionEndpoint(env *Environment, project mlp.Project, model *Model, ver
 		Environment:          env,
 		ResourceRequest:      env.DefaultResourceRequest,
 		DeploymentMode:       deployment.ServerlessDeploymentMode,
-		AutoscalingTarget:    autoscaling.DefaultServerlessAutoscalingTarget,
+		AutoscalingPolicy:    autoscaling.DefaultServerlessAutoscalingPolicy,
 	}
 
 	if monitoringConfig.MonitoringEnabled {

--- a/api/models/version_endpoint_test.go
+++ b/api/models/version_endpoint_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gojek/merlin/config"
 	"github.com/gojek/merlin/mlp"
+	"github.com/gojek/merlin/pkg/deployment"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,6 +28,7 @@ func TestVersionEndpoint(t *testing.T) {
 		monitoringConfig config.MonitoringConfig
 		isRunning        bool
 		isServing        bool
+		deploymentMode   deployment.Mode
 	}
 	tests := []struct {
 		name string
@@ -61,7 +63,7 @@ func TestVersionEndpoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errRaised := NewVersionEndpoint(&Environment{}, mlp.Project{}, &Model{}, &Version{}, tt.args.monitoringConfig)
+			errRaised := NewVersionEndpoint(&Environment{}, mlp.Project{}, &Model{}, &Version{}, tt.args.monitoringConfig, tt.args.deploymentMode)
 			assert.NotNil(t, errRaised)
 
 			if tt.args.isRunning {

--- a/api/pkg/autoscaling/autoscaling.go
+++ b/api/pkg/autoscaling/autoscaling.go
@@ -24,30 +24,30 @@ const (
 )
 
 var (
-	DefaultRawDeploymentAutoscalingTarget = &AutoscalingTarget{
+	DefaultRawDeploymentAutoscalingPolicy = &AutoscalingPolicy{
 		MetricsType: CPUUtilization,
 		TargetValue: 50,
 	}
 
-	DefaultServerlessAutoscalingTarget = &AutoscalingTarget{
+	DefaultServerlessAutoscalingPolicy = &AutoscalingPolicy{
 		MetricsType: Concurrency,
 		TargetValue: 1,
 	}
 )
 
-// AutoscalingTarget specify the metrics type and target value for autoscaling
-type AutoscalingTarget struct {
+// AutoscalingPolicy specify the metrics type and policy value for autoscaling
+type AutoscalingPolicy struct {
 	// MetricsType type of metrics to be used
 	MetricsType MetricsType `json:"metrics_type"`
-	// TargetValue specifies the target value
+	// TargetValue specifies the policy value
 	TargetValue float64 `json:"target_value"`
 }
 
-func (r AutoscalingTarget) Value() (driver.Value, error) {
+func (r AutoscalingPolicy) Value() (driver.Value, error) {
 	return json.Marshal(r)
 }
 
-func (r *AutoscalingTarget) Scan(value interface{}) error {
+func (r *AutoscalingPolicy) Scan(value interface{}) error {
 	b, ok := value.([]byte)
 	if !ok {
 		return errors.New("type assertion to []byte failed")
@@ -56,8 +56,8 @@ func (r *AutoscalingTarget) Scan(value interface{}) error {
 	return json.Unmarshal(b, &r)
 }
 
-// ValidateAutoscalingTarget check autoscaling target is valid and supported by the given deployment mode
-func ValidateAutoscalingTarget(target *AutoscalingTarget, mode deployment.Mode) error {
+// ValidateAutoscalingPolicy check autoscaling policy is valid and supported by the given deployment mode
+func ValidateAutoscalingPolicy(target *AutoscalingPolicy, mode deployment.Mode) error {
 	// raw deployment only support cpu utilization
 	if mode == deployment.RawDeploymentMode && target.MetricsType != CPUUtilization {
 		return merror.NewInvalidInputErrorf("raw_deployment doesn't support %v autoscaling metrics", target)
@@ -66,13 +66,13 @@ func ValidateAutoscalingTarget(target *AutoscalingTarget, mode deployment.Mode) 
 	// boundary check for cpu and memory utilization
 	if (target.MetricsType == CPUUtilization || target.MetricsType == MemoryUtilization) &&
 		(target.TargetValue <= 0 || target.TargetValue > 100) {
-		return merror.NewInvalidInputErrorf("target %v is outside 0-100 range", target.MetricsType)
+		return merror.NewInvalidInputErrorf("policy %v is outside 0-100 range", target.MetricsType)
 	}
 
 	// boundary check for rps and concurrency
 	if (target.MetricsType == Concurrency || target.MetricsType == RPS) &&
 		target.TargetValue <= 0 {
-		return merror.NewInvalidInputErrorf("target %v is less than or equal to 0", target.MetricsType)
+		return merror.NewInvalidInputErrorf("policy %v is less than or equal to 0", target.MetricsType)
 	}
 
 	return nil

--- a/api/pkg/autoscaling/autoscaling.go
+++ b/api/pkg/autoscaling/autoscaling.go
@@ -1,0 +1,79 @@
+package autoscaling
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+
+	"github.com/gojek/merlin/pkg/deployment"
+	merror "github.com/gojek/merlin/pkg/errors"
+)
+
+// MetricsType are supported metrics for autoscaling
+type MetricsType string
+
+const (
+	// CPUUtilization autoscaling based on cpu utilization (0-100 percent)
+	CPUUtilization MetricsType = "cpu_utilization"
+	// MemoryUtilization autoscaling based on memory utilization (0-100 percent)
+	MemoryUtilization MetricsType = "memory_utilization"
+	// Concurrency autoscaling based on number of concurrent request that the model should handle
+	Concurrency MetricsType = "concurrency"
+	// RPS autoscaling based on throughput (request per seconds)
+	RPS MetricsType = "rps"
+)
+
+var (
+	DefaultRawDeploymentAutoscalingTarget = &AutoscalingTarget{
+		MetricsType: CPUUtilization,
+		TargetValue: 50,
+	}
+
+	DefaultServerlessAutoscalingTarget = &AutoscalingTarget{
+		MetricsType: Concurrency,
+		TargetValue: 1,
+	}
+)
+
+// AutoscalingTarget specify the metrics type and target value for autoscaling
+type AutoscalingTarget struct {
+	// MetricsType type of metrics to be used
+	MetricsType MetricsType `json:"metrics_type"`
+	// TargetValue specifies the target value
+	TargetValue float64 `json:"target_value"`
+}
+
+func (r AutoscalingTarget) Value() (driver.Value, error) {
+	return json.Marshal(r)
+}
+
+func (r *AutoscalingTarget) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
+	}
+
+	return json.Unmarshal(b, &r)
+}
+
+// ValidateAutoscalingTarget check autoscaling target is valid and supported by the given deployment mode
+func ValidateAutoscalingTarget(target *AutoscalingTarget, mode deployment.Mode) error {
+	// raw deployment only support cpu utilization
+	if mode == deployment.RawDeploymentMode && target.MetricsType != CPUUtilization {
+		return merror.NewInvalidInputErrorf("raw_deployment doesn't support %v autoscaling metrics", target)
+	}
+
+	// boundary check for cpu and memory utilization
+	if (target.MetricsType == CPUUtilization || target.MetricsType == MemoryUtilization) &&
+		(target.TargetValue <= 0 || target.TargetValue > 100) {
+		return merror.NewInvalidInputErrorf("target %v is outside 0-100 range", target.MetricsType)
+	}
+
+	// boundary check for rps and concurrency
+	if (target.MetricsType == Concurrency || target.MetricsType == RPS) &&
+		target.TargetValue <= 0 {
+		return merror.NewInvalidInputErrorf("target %v is less than or equal to 0", target.MetricsType)
+	}
+
+	return nil
+}

--- a/api/pkg/autoscaling/autoscaling_test.go
+++ b/api/pkg/autoscaling/autoscaling_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/gojek/merlin/pkg/deployment"
 )
 
-func TestValidateAutoscalingTarget(t *testing.T) {
+func TestValidateAutoscalingPolicy(t *testing.T) {
 	type args struct {
-		target *AutoscalingTarget
+		policy *AutoscalingPolicy
 		mode   deployment.Mode
 	}
 	tests := []struct {
@@ -19,7 +19,7 @@ func TestValidateAutoscalingTarget(t *testing.T) {
 		{
 			name: "raw_deployment using cpu",
 			args: args{
-				target: &AutoscalingTarget{
+				policy: &AutoscalingPolicy{
 					MetricsType: CPUUtilization,
 					TargetValue: 10,
 				},
@@ -30,7 +30,7 @@ func TestValidateAutoscalingTarget(t *testing.T) {
 		{
 			name: "raw_deployment using cpu invalid value",
 			args: args{
-				target: &AutoscalingTarget{
+				policy: &AutoscalingPolicy{
 					MetricsType: CPUUtilization,
 					TargetValue: 110,
 				},
@@ -41,7 +41,7 @@ func TestValidateAutoscalingTarget(t *testing.T) {
 		{
 			name: "raw_deployment using memory",
 			args: args{
-				target: &AutoscalingTarget{
+				policy: &AutoscalingPolicy{
 					MetricsType: MemoryUtilization,
 					TargetValue: 10,
 				},
@@ -52,7 +52,7 @@ func TestValidateAutoscalingTarget(t *testing.T) {
 		{
 			name: "serverless using cpu",
 			args: args{
-				target: &AutoscalingTarget{
+				policy: &AutoscalingPolicy{
 					MetricsType: CPUUtilization,
 					TargetValue: 10,
 				},
@@ -63,7 +63,7 @@ func TestValidateAutoscalingTarget(t *testing.T) {
 		{
 			name: "serverless using memory",
 			args: args{
-				target: &AutoscalingTarget{
+				policy: &AutoscalingPolicy{
 					MetricsType: MemoryUtilization,
 					TargetValue: 10,
 				},
@@ -74,7 +74,7 @@ func TestValidateAutoscalingTarget(t *testing.T) {
 		{
 			name: "serverless using rps",
 			args: args{
-				target: &AutoscalingTarget{
+				policy: &AutoscalingPolicy{
 					MetricsType: RPS,
 					TargetValue: 10,
 				},
@@ -85,7 +85,7 @@ func TestValidateAutoscalingTarget(t *testing.T) {
 		{
 			name: "serverless using concurrency",
 			args: args{
-				target: &AutoscalingTarget{
+				policy: &AutoscalingPolicy{
 					MetricsType: Concurrency,
 					TargetValue: 10,
 				},
@@ -94,9 +94,9 @@ func TestValidateAutoscalingTarget(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "serverless using cpu invalid target",
+			name: "serverless using cpu invalid policy",
 			args: args{
-				target: &AutoscalingTarget{
+				policy: &AutoscalingPolicy{
 					MetricsType: CPUUtilization,
 					TargetValue: -1,
 				},
@@ -107,8 +107,8 @@ func TestValidateAutoscalingTarget(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ValidateAutoscalingTarget(tt.args.target, tt.args.mode); (err != nil) != tt.wantErr {
-				t.Errorf("ValidateAutoscalingTarget() error = %v, wantErr %v", err, tt.wantErr)
+			if err := ValidateAutoscalingPolicy(tt.args.policy, tt.args.mode); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAutoscalingPolicy() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/api/pkg/autoscaling/autoscaling_test.go
+++ b/api/pkg/autoscaling/autoscaling_test.go
@@ -1,0 +1,115 @@
+package autoscaling
+
+import (
+	"testing"
+
+	"github.com/gojek/merlin/pkg/deployment"
+)
+
+func TestValidateAutoscalingTarget(t *testing.T) {
+	type args struct {
+		target *AutoscalingTarget
+		mode   deployment.Mode
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "raw_deployment using cpu",
+			args: args{
+				target: &AutoscalingTarget{
+					MetricsType: CPUUtilization,
+					TargetValue: 10,
+				},
+				mode: deployment.RawDeploymentMode,
+			},
+			wantErr: false,
+		},
+		{
+			name: "raw_deployment using cpu invalid value",
+			args: args{
+				target: &AutoscalingTarget{
+					MetricsType: CPUUtilization,
+					TargetValue: 110,
+				},
+				mode: deployment.RawDeploymentMode,
+			},
+			wantErr: true,
+		},
+		{
+			name: "raw_deployment using memory",
+			args: args{
+				target: &AutoscalingTarget{
+					MetricsType: MemoryUtilization,
+					TargetValue: 10,
+				},
+				mode: deployment.RawDeploymentMode,
+			},
+			wantErr: true,
+		},
+		{
+			name: "serverless using cpu",
+			args: args{
+				target: &AutoscalingTarget{
+					MetricsType: CPUUtilization,
+					TargetValue: 10,
+				},
+				mode: deployment.ServerlessDeploymentMode,
+			},
+			wantErr: false,
+		},
+		{
+			name: "serverless using memory",
+			args: args{
+				target: &AutoscalingTarget{
+					MetricsType: MemoryUtilization,
+					TargetValue: 10,
+				},
+				mode: deployment.ServerlessDeploymentMode,
+			},
+			wantErr: false,
+		},
+		{
+			name: "serverless using rps",
+			args: args{
+				target: &AutoscalingTarget{
+					MetricsType: RPS,
+					TargetValue: 10,
+				},
+				mode: deployment.ServerlessDeploymentMode,
+			},
+			wantErr: false,
+		},
+		{
+			name: "serverless using concurrency",
+			args: args{
+				target: &AutoscalingTarget{
+					MetricsType: Concurrency,
+					TargetValue: 10,
+				},
+				mode: deployment.ServerlessDeploymentMode,
+			},
+			wantErr: false,
+		},
+		{
+			name: "serverless using cpu invalid target",
+			args: args{
+				target: &AutoscalingTarget{
+					MetricsType: CPUUtilization,
+					TargetValue: -1,
+				},
+				mode: deployment.ServerlessDeploymentMode,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateAutoscalingTarget(tt.args.target, tt.args.mode); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAutoscalingTarget() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/api/pkg/deployment/deployment_mode.go
+++ b/api/pkg/deployment/deployment_mode.go
@@ -1,0 +1,13 @@
+package deployment
+
+// Mode mode of the deployment
+type Mode string
+
+const (
+	// ServerlessDeploymentMode uses knative service as deployment method
+	ServerlessDeploymentMode Mode = "serverless"
+	// RawDeploymentMode uses k8s deployment as deployment method
+	RawDeploymentMode Mode = "raw_deployment"
+	// EmptyMode
+	EmptyDeploymentMode Mode = ""
+)

--- a/api/pkg/errors/errors.go
+++ b/api/pkg/errors/errors.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	InvalidInputError error = errors.New("invalid input")
+)
+
+// NewInvalidInputError create new InvalidInputError with specified reason
+// errors.Is(error, InvalidInputError) will return true if a new error is created using this function
+func NewInvalidInputError(reason string) error {
+	return fmt.Errorf("%w: %s", InvalidInputError, reason)
+}
+
+// NewInvalidInputErrorf create new InvalidInputError with specified reason string format
+// errors.Is(error, InvalidInputError) will return true if a new error is created using this function
+func NewInvalidInputErrorf(reasonFormat string, a ...interface{}) error {
+	return fmt.Errorf("%w: %s", InvalidInputError, fmt.Sprintf(reasonFormat, a...))
+}

--- a/api/queue/work/model_service_deployment.go
+++ b/api/queue/work/model_service_deployment.go
@@ -107,7 +107,7 @@ func (depl *ModelServiceDeployment) Deploy(job *queue.Job) error {
 		return err
 	}
 
-	modelService := models.NewService(model, version, modelOpt, endpoint.ResourceRequest, endpoint.EnvVars, endpoint.EnvironmentName, endpoint.Transformer, endpoint.Logger, endpoint.DeploymentMode, endpoint.AutoscalingTarget)
+	modelService := models.NewService(model, version, modelOpt, endpoint.ResourceRequest, endpoint.EnvVars, endpoint.EnvironmentName, endpoint.Transformer, endpoint.Logger, endpoint.DeploymentMode, endpoint.AutoscalingPolicy)
 	ctl, ok := depl.ClusterControllers[endpoint.EnvironmentName]
 	if !ok {
 		return fmt.Errorf("unable to find cluster controller for environment %s", endpoint.EnvironmentName)

--- a/api/queue/work/model_service_deployment.go
+++ b/api/queue/work/model_service_deployment.go
@@ -107,7 +107,7 @@ func (depl *ModelServiceDeployment) Deploy(job *queue.Job) error {
 		return err
 	}
 
-	modelService := models.NewService(model, version, modelOpt, endpoint.ResourceRequest, endpoint.EnvVars, endpoint.EnvironmentName, endpoint.Transformer, endpoint.Logger, endpoint.DeploymentMode)
+	modelService := models.NewService(model, version, modelOpt, endpoint.ResourceRequest, endpoint.EnvVars, endpoint.EnvironmentName, endpoint.Transformer, endpoint.Logger, endpoint.DeploymentMode, endpoint.AutoscalingTarget)
 	ctl, ok := depl.ClusterControllers[endpoint.EnvironmentName]
 	if !ok {
 		return fmt.Errorf("unable to find cluster controller for environment %s", endpoint.EnvironmentName)

--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -121,12 +121,12 @@ func (k *endpointService) DeployEndpoint(ctx context.Context, environment *model
 		endpoint.DeploymentMode = newEndpoint.DeploymentMode
 	}
 
-	if newEndpoint.AutoscalingTarget != nil {
-		err := autoscaling.ValidateAutoscalingTarget(newEndpoint.AutoscalingTarget, endpoint.DeploymentMode)
+	if newEndpoint.AutoscalingPolicy != nil {
+		err := autoscaling.ValidateAutoscalingPolicy(newEndpoint.AutoscalingPolicy, endpoint.DeploymentMode)
 		if err != nil {
 			return nil, err
 		}
-		endpoint.AutoscalingTarget = newEndpoint.AutoscalingTarget
+		endpoint.AutoscalingPolicy = newEndpoint.AutoscalingPolicy
 	}
 
 	if newEndpoint.Transformer != nil {

--- a/api/utils/maps.go
+++ b/api/utils/maps.go
@@ -1,0 +1,35 @@
+package utils
+
+// MergeMaps combine 2 maps string of string and return a new map
+// keys in 'right' map is given priority if there is duplicate key in 'left' map
+func MergeMaps(left map[string]string, right map[string]string) map[string]string {
+	output := make(map[string]string)
+
+	for k, v := range left {
+		output[k] = v
+	}
+
+	for k, v := range right {
+		output[k] = v
+	}
+
+	return output
+}
+
+// ExcludeKeys create a new map that exclude certain keys in the original map
+func ExcludeKeys(srcMap map[string]string, keysToExclude []string) map[string]string {
+	output := make(map[string]string)
+	keysToExcludeMap := make(map[string]bool)
+
+	for _, key := range keysToExclude {
+		keysToExcludeMap[key] = true
+	}
+
+	for k, v := range srcMap {
+		if keysToExcludeMap[k] == true {
+			continue
+		}
+		output[k] = v
+	}
+	return output
+}

--- a/api/utils/maps_test.go
+++ b/api/utils/maps_test.go
@@ -1,0 +1,133 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeMaps(t *testing.T) {
+	type args struct {
+		left  map[string]string
+		right map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "both maps has different keys",
+			args: args{
+				left: map[string]string{
+					"key-1": "value-1",
+				},
+				right: map[string]string{
+					"key-2": "value-2",
+				},
+			},
+			want: map[string]string{
+				"key-1": "value-1",
+				"key-2": "value-2",
+			},
+		},
+		{
+			name: "duplicate key",
+			args: args{
+				left: map[string]string{
+					"key-1": "value-1",
+				},
+				right: map[string]string{
+					"key-1": "value-11",
+					"key-2": "value-2",
+				},
+			},
+			want: map[string]string{
+				"key-1": "value-11",
+				"key-2": "value-2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MergeMaps(tt.args.left, tt.args.right); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MergeMaps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExcludeKeys(t *testing.T) {
+	type args struct {
+		srcMap        map[string]string
+		keysToExclude []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "all keys not in map",
+			args: args{
+				srcMap: map[string]string{
+					"key-1": "value-1",
+					"key-2": "value-2",
+					"key-3": "value-3",
+					"key-4": "value-4",
+				},
+				keysToExclude: []string{
+					"key-not-found",
+				},
+			},
+			want: map[string]string{
+				"key-1": "value-1",
+				"key-2": "value-2",
+				"key-3": "value-3",
+				"key-4": "value-4",
+			},
+		},
+		{
+			name: "all keys in map",
+			args: args{
+				srcMap: map[string]string{
+					"key-1": "value-1",
+					"key-2": "value-2",
+					"key-3": "value-3",
+					"key-4": "value-4",
+				},
+				keysToExclude: []string{
+					"key-2", "key-3",
+				},
+			},
+			want: map[string]string{
+				"key-1": "value-1",
+				"key-4": "value-4",
+			},
+		},
+		{
+			name: "some keys in map",
+			args: args{
+				srcMap: map[string]string{
+					"key-1": "value-1",
+					"key-2": "value-2",
+					"key-3": "value-3",
+					"key-4": "value-4",
+				},
+				keysToExclude: []string{
+					"key-2", "key-3", "key-not-found",
+				},
+			},
+			want: map[string]string{
+				"key-1": "value-1",
+				"key-4": "value-4",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExcludeKeys(tt.args.srcMap, tt.args.keysToExclude); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExcludeKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/db-migrations/28_autoscaling_config.down.sql
+++ b/db-migrations/28_autoscaling_config.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE version_endpoints DROP COLUMN autoscaling_target;

--- a/db-migrations/28_autoscaling_config.down.sql
+++ b/db-migrations/28_autoscaling_config.down.sql
@@ -1,1 +1,0 @@
-ALTER TABLE version_endpoints DROP COLUMN autoscaling_target;

--- a/db-migrations/28_autoscaling_config.up.sql
+++ b/db-migrations/28_autoscaling_config.up.sql
@@ -1,1 +1,0 @@
-ALTER TABLE version_endpoints ADD COLUMN autoscaling_target jsonb;

--- a/db-migrations/28_autoscaling_config.up.sql
+++ b/db-migrations/28_autoscaling_config.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE version_endpoints ADD COLUMN autoscaling_target jsonb;

--- a/db-migrations/28_autoscaling_policy.down.sql
+++ b/db-migrations/28_autoscaling_policy.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE version_endpoints DROP COLUMN autoscaling_policy;

--- a/db-migrations/28_autoscaling_policy.up.sql
+++ b/db-migrations/28_autoscaling_policy.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE version_endpoints ADD COLUMN autoscaling_policy jsonb;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1253,6 +1253,8 @@ definitions:
         $ref: "#/definitions/Logger"
       deployment_mode:
         $ref: "#/definitions/DeploymentMode"
+      autoscaling_target:
+        $ref: "#/definitions/AutoscalingTarget"
       created_at:
         type: "string"
         format: "date-time"
@@ -1352,6 +1354,22 @@ definitions:
         type: "string"
       memory_request:
         type: "string"
+
+
+  AutoscalingTarget:
+    type: "object"
+    properties:
+      metrics_type:
+        type:  "#/definitions/MetricsType"
+      target_value:
+        type: "number"
+
+  MetricsType:
+    enum:
+    - "concurrency"
+    - "cpu_utilization"
+    - "memory_utilization"
+    - "rps"
 
   EnvVar:
     type: "object"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1253,8 +1253,8 @@ definitions:
         $ref: "#/definitions/Logger"
       deployment_mode:
         $ref: "#/definitions/DeploymentMode"
-      autoscaling_target:
-        $ref: "#/definitions/AutoscalingTarget"
+      autoscaling_policy:
+        $ref: "#/definitions/AutoscalingPolicy"
       created_at:
         type: "string"
         format: "date-time"
@@ -1356,7 +1356,7 @@ definitions:
         type: "string"
 
 
-  AutoscalingTarget:
+  AutoscalingPolicy:
     type: "object"
     properties:
       metrics_type:


### PR DESCRIPTION
Signed-off-by: Pradithya Aria <pradithya.pura@go-jek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Allow user to configure autoscaling strategy. Currently supported metrics are:
1. CPU
2. Memory
3. Concurrency
4. RPS

Depending on the deployment mode, not all metrics are accepted. i.e. : Raw Deployment only supports CPU, whereas Serverless deployment supports all above metrics.

User can pass `AutoscalingTarget` to configure it. Note: I'm still not comfortable with the name, some candidates:
- AutoscalingPolicy
- AutoscalingConfig
- AutoscalingStrategy

What's your thought?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Implement configurable autoscaling strategy
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [x] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes 
