### PR TITLE
Fix insert cache with NaN value

### DIFF
--- a/api/pkg/transformer/feast/default_value.go
+++ b/api/pkg/transformer/feast/default_value.go
@@ -28,7 +28,7 @@ func compileDefaultValues(featureTableSpecs []*spec.FeatureTable) defaultValues 
 			if len(f.DefaultValue) != 0 {
 				feastValType := feastTypes.ValueType_Enum(feastTypes.ValueType_Enum_value[f.ValueType])
 				defVal, err := converter.ToFeastValue(f.DefaultValue, feastValType)
-				if err != nil {
+				if err != nil || defVal == nil {
 					continue
 				}
 

--- a/api/pkg/transformer/types/converter/converter.go
+++ b/api/pkg/transformer/types/converter/converter.go
@@ -1008,7 +1008,6 @@ func extractArrayFromString(str interface{}, delimiter string) (interface{}, err
 }
 
 func ExtractFeastValue(val *feastType.Value) (interface{}, feastType.ValueType_Enum, error) {
-	fmt.Printf("val: %+v and type %T\n", val, val)
 	switch val.Val.(type) {
 	case *feastType.Value_StringVal:
 		return val.GetStringVal(), feastType.ValueType_STRING, nil

--- a/api/pkg/transformer/types/converter/converter_test.go
+++ b/api/pkg/transformer/types/converter/converter_test.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"encoding/base64"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -1654,6 +1655,14 @@ func TestToFloat32List(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from NaN float32",
+			args: args{
+				val: float32(math.NaN()),
+			},
+			want:    []float32{},
+			wantErr: false,
+		},
+		{
 			name: "from float64",
 			args: args{
 				val: float64(3.14),
@@ -1662,9 +1671,17 @@ func TestToFloat32List(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from NaN float64",
+			args: args{
+				val: math.NaN(),
+			},
+			want:    []float32{},
+			wantErr: false,
+		},
+		{
 			name: "from []float32",
 			args: args{
-				val: []float32{float32(3.14), float32(4.56)},
+				val: []float32{float32(3.14), float32(4.56), float32(math.NaN())},
 			},
 			want:    []float32{3.14, 4.56},
 			wantErr: false,
@@ -1672,7 +1689,7 @@ func TestToFloat32List(t *testing.T) {
 		{
 			name: "from []float64",
 			args: args{
-				val: []float64{float64(3.14), float64(4.56)},
+				val: []float64{float64(3.14), math.NaN(), float64(4.56)},
 			},
 			want:    []float32{3.14, 4.56},
 			wantErr: false,
@@ -1696,7 +1713,7 @@ func TestToFloat32List(t *testing.T) {
 		{
 			name: "from []string",
 			args: args{
-				val: []string{"23.3", "30.09"},
+				val: []string{"23.3", "30.09", "NaN"},
 			},
 			want:    []float32{23.3, 30.09},
 			wantErr: false,
@@ -1736,7 +1753,7 @@ func TestToFloat32List(t *testing.T) {
 		{
 			name: "from []interface",
 			args: args{
-				val: []interface{}{0, 1, 10},
+				val: []interface{}{0, 1, 10, math.NaN(), "NaN"},
 			},
 			want:    []float32{0, 1, 10},
 			wantErr: false,
@@ -1823,11 +1840,27 @@ func TestToFloat64List(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "from float64",
+			name: "from NaN float32",
 			args: args{
-				val: float64(3.14),
+				val: float32(math.NaN()),
+			},
+			want:    []float64{},
+			wantErr: false,
+		},
+		{
+			name: "from float32",
+			args: args{
+				val: float32(3.14),
 			},
 			want:    []float64{3.14},
+			wantErr: false,
+		},
+		{
+			name: "from NaN float64",
+			args: args{
+				val: math.NaN(),
+			},
+			want:    []float64{},
 			wantErr: false,
 		},
 		{
@@ -1841,15 +1874,15 @@ func TestToFloat64List(t *testing.T) {
 		{
 			name: "from []float64",
 			args: args{
-				val: []float64{float64(3.14), float64(4.56)},
+				val: []float64{float64(3.14), float64(4.56), math.NaN()},
 			},
 			want:    []float64{3.14, 4.56},
 			wantErr: false,
 		},
 		{
-			name: "from []float64",
+			name: "from []float32",
 			args: args{
-				val: []float64{float64(3.14), float64(4.56)},
+				val: []float32{float32(3.14), float32(math.NaN())},
 			},
 			want:    []float64{3.14, 4.56},
 			wantErr: false,
@@ -1863,6 +1896,14 @@ func TestToFloat64List(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "from NaN string",
+			args: args{
+				val: "NaN",
+			},
+			want:    []float64{},
+			wantErr: false,
+		},
+		{
 			name: "from string - invalid",
 			args: args{
 				val: "asd",
@@ -1873,7 +1914,7 @@ func TestToFloat64List(t *testing.T) {
 		{
 			name: "from []string",
 			args: args{
-				val: []string{"23.3", "30.09"},
+				val: []string{"23.3", "30.09", "NaN"},
 			},
 			want:    []float64{23.3, 30.09},
 			wantErr: false,
@@ -1913,7 +1954,7 @@ func TestToFloat64List(t *testing.T) {
 		{
 			name: "from []interface",
 			args: args{
-				val: []interface{}{3.14, 1, 10},
+				val: []interface{}{3.14, 1, 10, "NaN", math.NaN()},
 			},
 			want:    []float64{3.14, 1, 10},
 			wantErr: false,
@@ -2219,12 +2260,48 @@ func TestToFeastValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "float32 from NaN string",
+			args: args{
+				v:         "NaN",
+				valueType: types.ValueType_FLOAT,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "float32 from NaN ",
+			args: args{
+				v:         float32(math.NaN()),
+				valueType: types.ValueType_FLOAT,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
 			name: "double",
 			args: args{
-				v:         float64(3.14),
+				v:         float64(0.201),
 				valueType: types.ValueType_DOUBLE,
 			},
-			want:    &types.Value{Val: &types.Value_DoubleVal{DoubleVal: 3.14}},
+			want:    &types.Value{Val: &types.Value_DoubleVal{DoubleVal: 0.201}},
+			wantErr: false,
+		},
+		{
+			name: "double from NaN string",
+			args: args{
+				v:         "NaN",
+				valueType: types.ValueType_DOUBLE,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "double from NaN ",
+			args: args{
+				v:         math.NaN(),
+				valueType: types.ValueType_DOUBLE,
+			},
+			want:    nil,
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
There is issue when insert cache that contains `NaN` value. To solve this, we change all `NaN` to nil because it will be converted to nil eventually
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
