### PR TITLE
Fix slice row ui when delete entry in start or end index

### DIFF
--- a/ui/src/pages/version/components/forms/components/transformer/components/table_operations/SliceRow.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_operations/SliceRow.js
@@ -26,7 +26,7 @@ export const SliceRow = ({ sliceRow, onChangeHandler, errors = {} }) => {
           fullWidth>
           <EuiFieldText
             placeholder="Start Index"
-            value={!!sliceRow && sliceRow.start ? sliceRow.start : "null"}
+            value={!!sliceRow && sliceRow.start ? sliceRow.start : ""}
             onChange={e => onChange("start")(e.target.value)}
             isInvalid={!!errors.name}
             name={`start`}
@@ -48,7 +48,7 @@ export const SliceRow = ({ sliceRow, onChangeHandler, errors = {} }) => {
           fullWidth>
           <EuiFieldText
             placeholder="End Index"
-            value={!!sliceRow && sliceRow.end ? sliceRow.end : "null"}
+            value={!!sliceRow && sliceRow.end ? sliceRow.end : ""}
             onChange={e => onChange("end")(e.target.value)}
             isInvalid={!!errors.name}
             name={`end`}

--- a/ui/src/services/transformer/TransformerConfig.js
+++ b/ui/src/services/transformer/TransformerConfig.js
@@ -419,10 +419,10 @@ export class Pipeline {
             }
             if (step.operation === "sliceRow") {
               if (step.sliceRow) {
-                if (step.sliceRow.start) {
+                if (step.sliceRow.start !== undefined) {
                   step.sliceRow.start = parseInt(step.sliceRow.start);
                 }
-                if (step.sliceRow.end) {
+                if (step.sliceRow.end !== undefined) {
                   step.sliceRow.end = parseInt(step.sliceRow.end);
                 }
               }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
During testing the RC found glitch in UI where user can delete `start` and `end` index on `SliceRow` transformation step without blocking whole value.

https://user-images.githubusercontent.com/2369255/162852601-38918659-8317-4dcb-ae8b-583979fe107f.mov


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

https://user-images.githubusercontent.com/2369255/162852736-5de888b8-eebd-48bb-b200-71291f4ed364.mov



```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [X] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
