### PR TITLE
Use sorted order of the entities for bigtable

### DIFF
--- a/api/pkg/transformer/feast/bigtablestore/encoding.go
+++ b/api/pkg/transformer/feast/bigtablestore/encoding.go
@@ -55,6 +55,7 @@ func entitiesToEntityNames(entities []*spec.Entity) []string {
 }
 
 func entityKeysToBigTable(project string, entityNames []string) string {
+	sort.Strings(entityNames)
 	fullTableName := project + "__" + strings.Join(entityNames, "__")
 	if len(fullTableName) <= maxTableNameLength {
 		return fullTableName

--- a/api/pkg/transformer/feast/bigtablestore/encoding_test.go
+++ b/api/pkg/transformer/feast/bigtablestore/encoding_test.go
@@ -1012,6 +1012,19 @@ func TestEntityKeysToBigTable(t *testing.T) {
 			},
 			want: "default-project-mobility-nationwide__drivede1619bb",
 		},
+		{
+			desc:    "sort entity keys",
+			project: "default",
+			entityKeys: []*spec.Entity{
+				{
+					Name: "driver_id",
+				},
+				{
+					Name: "driver_geohash",
+				},
+			},
+			want: "default__driver_geohash__driver_id",
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Due to changes in https://github.com/feast-dev/feast-spark/pull/138/files, the feature retrieval in direct bigtable retrieval needs to be updated as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
For feature table with two or more entities, data might need to be reingested using the Feast jobservice version with the fix in https://github.com/feast-dev/feast-spark/pull/138/files as the location of the table might have been changed.
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
