### PR TITLE
Upgrade cloudpickle to 2.0.0

### DIFF
--- a/python/batch-predictor/requirements.txt
+++ b/python/batch-predictor/requirements.txt
@@ -1,6 +1,6 @@
 pyspark==2.4.5
 mlflow==1.6.0
-cloudpickle==1.2.2
+cloudpickle==2.0.0
 pyarrow==0.14.1
 protobuf>=3.0
 file:../sdk#egg=merlin-sdk

--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -2,7 +2,7 @@ kfserving==0.2.1.1
 argparse>=1.4.0
 numpy >= 1.8.2
 mlflow==1.6.0
-cloudpickle==1.2.2
+cloudpickle==2.0.0
 prometheus_client==0.7.1
 uvloop>=0.15.2
 orjson==2.6.8

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -31,7 +31,7 @@ REQUIRES = [
     "PyPrind>=2.11.2",
     "google-auth>=1.11.0,<2.0dev",
     'Click>=7.0',
-    "cloudpickle==1.2.2",
+    "cloudpickle==2.0.0",
     "cookiecutter>=1.7.2",
     "docker>=4.2.1",
     "PyYAML>=5.4"


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade cloudpickle version from 1.2.2 to 2.0.0


```release-note
Cloudpickle version pinned to version 2.0.0 up from 1.2.2
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
