### PR TITLE
Update alert's metrics that depends to old kube-state-metrics' metrics

### DIFF
--- a/api/models/model_endpoint_alert.go
+++ b/api/models/model_endpoint_alert.go
@@ -34,8 +34,8 @@ const (
 	throughputSliExprFormat = "round(sum(rate(revision_request_count{cluster_name=\"%s\",namespace_name=\"%s\",revision_name=~\".*%s.*\"}[1m])), 0.001)"
 	latencySliExprFormat    = "histogram_quantile(%f, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name=\"%s\",namespace_name=\"%s\",revision_name=~\".*%s.*\"}[1m])))"
 	errorRateSliExprFormat  = "(100 * sum(rate(revision_request_count{cluster_name=\"%s\",namespace_name=\"%s\",response_code_class!=\"2xx\",revision_name=~\".*%s.*\"}[1m])) / sum(rate(revision_request_count{cluster_name=\"%s\",namespace_name=\"%s\",revision_name=~\".*%s.*\"}[1m])))"
-	cpuSliExprFormat        = "(100 * sum(rate(container_cpu_usage_seconds_total{cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}[1m])) / sum(kube_pod_container_resource_requests_cpu_cores{cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}))"
-	memorySliExprFormat     = "(100 * sum(container_memory_usage_bytes{cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}) / sum(kube_pod_container_resource_requests_memory_bytes{cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}))"
+	cpuSliExprFormat        = "(100 * sum(rate(container_cpu_usage_seconds_total{cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}[1m])) / sum(kube_pod_container_resource_requests{resource=\"cpu\",cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}))"
+	memorySliExprFormat     = "(100 * sum(container_memory_usage_bytes{cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}) / sum(kube_pod_container_resource_requests{resource=\"memory\",cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}))"
 )
 
 const (

--- a/api/models/model_endpoint_alert_test.go
+++ b/api/models/model_endpoint_alert_test.go
@@ -279,7 +279,7 @@ func TestModelEndpointAlert_ToPromAlertSpec(t *testing.T) {
 									Kind:  yamlv3.ScalarNode,
 									Style: yamlv3.LiteralStyle,
 									Tag:   "!!str",
-									Value: "(100 * sum(rate(container_cpu_usage_seconds_total{cluster_name=\"cluster-1\",container!~\"|POD\",namespace=\"project-1\",pod=~\".*model-1.*\"}[1m])) / sum(kube_pod_container_resource_requests_cpu_cores{cluster_name=\"cluster-1\",container!~\"|POD\",namespace=\"project-1\",pod=~\".*model-1.*\"})) > 50",
+									Value: "(100 * sum(rate(container_cpu_usage_seconds_total{cluster_name=\"cluster-1\",container!~\"|POD\",namespace=\"project-1\",pod=~\".*model-1.*\"}[1m])) / sum(kube_pod_container_resource_requests{cluster_name=\"cluster-1\",container!~\"|POD\",namespace=\"project-1\",pod=~\".*model-1.*\",resource=\"cpu\"})) > 50",
 								},
 								For: "5m",
 								Labels: PromAlertRuleLabels{
@@ -342,7 +342,7 @@ func TestModelEndpointAlert_ToPromAlertSpec(t *testing.T) {
 									Kind:  yamlv3.ScalarNode,
 									Style: yamlv3.LiteralStyle,
 									Tag:   "!!str",
-									Value: "(100 * sum(container_memory_usage_bytes{cluster_name=\"cluster-1\",container!~\"|POD\",namespace=\"project-1\",pod=~\".*model-1.*\"}) / sum(kube_pod_container_resource_requests_memory_bytes{cluster_name=\"cluster-1\",container!~\"|POD\",namespace=\"project-1\",pod=~\".*model-1.*\"})) > 50",
+									Value: "(100 * sum(container_memory_usage_bytes{cluster_name=\"cluster-1\",container!~\"|POD\",namespace=\"project-1\",pod=~\".*model-1.*\"}) / sum(kube_pod_container_resource_requests{cluster_name=\"cluster-1\",container!~\"|POD\",namespace=\"project-1\",pod=~\".*model-1.*\",resource=\"memory\"})) > 50",
 								},
 								For: "5m",
 								Labels: PromAlertRuleLabels{

--- a/api/service/testdata/model_endpoint_alert.yaml
+++ b/api/service/testdata/model_endpoint_alert.yaml
@@ -1,147 +1,147 @@
 groups:
-  - name: merlin_project-1_model-1_env-1
-    rules:
-      - alert: "[merlin] model-1: Throughput warning"
-        expr: |-
-          round(sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m])), 0.001) < 1
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: warning
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: Throughput (RPM) of model-1 model in env-1 is less than 1.00. Current value is {{ $value }}.
-      - alert: "[merlin] model-1: Throughput critical"
-        expr: |-
-          round(sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m])), 0.001) < 2
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: critical
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: Throughput (RPM) of model-1 model in env-1 is less than 2.00. Current value is {{ $value }}.
-      - alert: "[merlin] model-1: 99.00p Latency warning"
-        expr: |-
-          histogram_quantile(0.99, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 3
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: warning
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: 99.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 3.00 ms. Current value is {{ $value }} ms.
-      - alert: "[merlin] model-1: 99.00p Latency critical"
-        expr: |-
-          histogram_quantile(0.99, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 4
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: critical
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: 99.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 4.00 ms. Current value is {{ $value }} ms.
-      - alert: "[merlin] model-1: 95.00p Latency warning"
-        expr: |-
-          histogram_quantile(0.95, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 5
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: warning
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: 95.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 5.00 ms. Current value is {{ $value }} ms.
-      - alert: "[merlin] model-1: 95.00p Latency critical"
-        expr: |-
-          histogram_quantile(0.95, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 6
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: critical
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: 95.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 6.00 ms. Current value is {{ $value }} ms.
-      - alert: "[merlin] model-1: Error Rate warning"
-        expr: |-
-          (100 * sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",response_code_class!="2xx",revision_name=~".*model-1.*"}[1m])) / sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 7
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: warning
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: Error rate of model-1 model in env-1 is higher than 7.00%. Current value is {{ $value }}%.
-      - alert: "[merlin] model-1: Error Rate critical"
-        expr: |-
-          (100 * sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",response_code_class!="2xx",revision_name=~".*model-1.*"}[1m])) / sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 8
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: critical
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: Error rate of model-1 model in env-1 is higher than 8.00%. Current value is {{ $value }}%.
-      - alert: "[merlin] model-1: Cpu warning"
-        expr: |-
-          (100 * sum(rate(container_cpu_usage_seconds_total{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}[1m])) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="cpu"})) > 9
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: warning
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: CPU usage of model-1 model in env-1 is higher than 9.00%. Current value is {{ $value }}%.
-      - alert: "[merlin] model-1: Cpu critical"
-        expr: |-
-          (100 * sum(rate(container_cpu_usage_seconds_total{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}[1m])) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="cpu"})) > 10
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: critical
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: CPU usage of model-1 model in env-1 is higher than 10.00%. Current value is {{ $value }}%.
-      - alert: "[merlin] model-1: Memory warning"
-        expr: |-
-          (100 * sum(container_memory_usage_bytes{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="memory"})) > 11
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: warning
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: Memory usage of model-1 model in env-1 is higher than 11.00%. Current value is {{ $value }}%.
-      - alert: "[merlin] model-1: Memory critical"
-        expr: |-
-          (100 * sum(container_memory_usage_bytes{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="memory"})) > 12
-        for: 5m
-        labels:
-          owner: team-1
-          service_name: merlin_project-1_model-1_env-1
-          severity: critical
-        annotations:
-          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-          playbook: TODO
-          summary: Memory usage of model-1 model in env-1 is higher than 12.00%. Current value is {{ $value }}%.
+    - name: merlin_project-1_model-1_env-1
+      rules:
+        - alert: "[merlin] model-1: Throughput warning"
+          expr: |-
+            round(sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m])), 0.001) < 1
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: warning
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: Throughput (RPM) of model-1 model in env-1 is less than 1.00. Current value is {{ $value }}.
+        - alert: "[merlin] model-1: Throughput critical"
+          expr: |-
+            round(sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m])), 0.001) < 2
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: critical
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: Throughput (RPM) of model-1 model in env-1 is less than 2.00. Current value is {{ $value }}.
+        - alert: "[merlin] model-1: 99.00p Latency warning"
+          expr: |-
+            histogram_quantile(0.99, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 3
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: warning
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: 99.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 3.00 ms. Current value is {{ $value }} ms.
+        - alert: "[merlin] model-1: 99.00p Latency critical"
+          expr: |-
+            histogram_quantile(0.99, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 4
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: critical
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: 99.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 4.00 ms. Current value is {{ $value }} ms.
+        - alert: "[merlin] model-1: 95.00p Latency warning"
+          expr: |-
+            histogram_quantile(0.95, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 5
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: warning
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: 95.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 5.00 ms. Current value is {{ $value }} ms.
+        - alert: "[merlin] model-1: 95.00p Latency critical"
+          expr: |-
+            histogram_quantile(0.95, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 6
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: critical
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: 95.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 6.00 ms. Current value is {{ $value }} ms.
+        - alert: "[merlin] model-1: Error Rate warning"
+          expr: |-
+            (100 * sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",response_code_class!="2xx",revision_name=~".*model-1.*"}[1m])) / sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 7
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: warning
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: Error rate of model-1 model in env-1 is higher than 7.00%. Current value is {{ $value }}%.
+        - alert: "[merlin] model-1: Error Rate critical"
+          expr: |-
+            (100 * sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",response_code_class!="2xx",revision_name=~".*model-1.*"}[1m])) / sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 8
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: critical
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: Error rate of model-1 model in env-1 is higher than 8.00%. Current value is {{ $value }}%.
+        - alert: "[merlin] model-1: Cpu warning"
+          expr: |-
+            (100 * sum(rate(container_cpu_usage_seconds_total{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}[1m])) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="cpu"})) > 9
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: warning
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: CPU usage of model-1 model in env-1 is higher than 9.00%. Current value is {{ $value }}%.
+        - alert: "[merlin] model-1: Cpu critical"
+          expr: |-
+            (100 * sum(rate(container_cpu_usage_seconds_total{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}[1m])) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="cpu")) > 10
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: critical
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: CPU usage of model-1 model in env-1 is higher than 10.00%. Current value is {{ $value }}%.
+        - alert: "[merlin] model-1: Memory warning"
+          expr: |-
+            (100 * sum(container_memory_usage_bytes{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="memory"})) > 11
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: warning
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: Memory usage of model-1 model in env-1 is higher than 11.00%. Current value is {{ $value }}%.
+        - alert: "[merlin] model-1: Memory critical"
+          expr: |-
+            (100 * sum(container_memory_usage_bytes{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="memory"})) > 12
+          for: 5m
+          labels:
+            owner: team-1
+            service_name: merlin_project-1_model-1_env-1
+            severity: critical
+          annotations:
+            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+            playbook: TODO
+            summary: Memory usage of model-1 model in env-1 is higher than 12.00%. Current value is {{ $value }}%.

--- a/api/service/testdata/model_endpoint_alert.yaml
+++ b/api/service/testdata/model_endpoint_alert.yaml
@@ -1,147 +1,147 @@
 groups:
-    - name: merlin_project-1_model-1_env-1
-      rules:
-        - alert: "[merlin] model-1: Throughput warning"
-          expr: |-
-            round(sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m])), 0.001) < 1
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: warning
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: Throughput (RPM) of model-1 model in env-1 is less than 1.00. Current value is {{ $value }}.
-        - alert: "[merlin] model-1: Throughput critical"
-          expr: |-
-            round(sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m])), 0.001) < 2
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: critical
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: Throughput (RPM) of model-1 model in env-1 is less than 2.00. Current value is {{ $value }}.
-        - alert: "[merlin] model-1: 99.00p Latency warning"
-          expr: |-
-            histogram_quantile(0.99, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 3
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: warning
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: 99.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 3.00 ms. Current value is {{ $value }} ms.
-        - alert: "[merlin] model-1: 99.00p Latency critical"
-          expr: |-
-            histogram_quantile(0.99, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 4
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: critical
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: 99.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 4.00 ms. Current value is {{ $value }} ms.
-        - alert: "[merlin] model-1: 95.00p Latency warning"
-          expr: |-
-            histogram_quantile(0.95, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 5
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: warning
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: 95.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 5.00 ms. Current value is {{ $value }} ms.
-        - alert: "[merlin] model-1: 95.00p Latency critical"
-          expr: |-
-            histogram_quantile(0.95, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 6
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: critical
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: 95.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 6.00 ms. Current value is {{ $value }} ms.
-        - alert: "[merlin] model-1: Error Rate warning"
-          expr: |-
-            (100 * sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",response_code_class!="2xx",revision_name=~".*model-1.*"}[1m])) / sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 7
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: warning
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: Error rate of model-1 model in env-1 is higher than 7.00%. Current value is {{ $value }}%.
-        - alert: "[merlin] model-1: Error Rate critical"
-          expr: |-
-            (100 * sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",response_code_class!="2xx",revision_name=~".*model-1.*"}[1m])) / sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 8
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: critical
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: Error rate of model-1 model in env-1 is higher than 8.00%. Current value is {{ $value }}%.
-        - alert: "[merlin] model-1: Cpu warning"
-          expr: |-
-            (100 * sum(rate(container_cpu_usage_seconds_total{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}[1m])) / sum(kube_pod_container_resource_requests_cpu_cores{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"})) > 9
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: warning
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: CPU usage of model-1 model in env-1 is higher than 9.00%. Current value is {{ $value }}%.
-        - alert: "[merlin] model-1: Cpu critical"
-          expr: |-
-            (100 * sum(rate(container_cpu_usage_seconds_total{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}[1m])) / sum(kube_pod_container_resource_requests_cpu_cores{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"})) > 10
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: critical
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: CPU usage of model-1 model in env-1 is higher than 10.00%. Current value is {{ $value }}%.
-        - alert: "[merlin] model-1: Memory warning"
-          expr: |-
-            (100 * sum(container_memory_usage_bytes{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}) / sum(kube_pod_container_resource_requests_memory_bytes{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"})) > 11
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: warning
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: Memory usage of model-1 model in env-1 is higher than 11.00%. Current value is {{ $value }}%.
-        - alert: "[merlin] model-1: Memory critical"
-          expr: |-
-            (100 * sum(container_memory_usage_bytes{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}) / sum(kube_pod_container_resource_requests_memory_bytes{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"})) > 12
-          for: 5m
-          labels:
-            owner: team-1
-            service_name: merlin_project-1_model-1_env-1
-            severity: critical
-          annotations:
-            dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
-            playbook: TODO
-            summary: Memory usage of model-1 model in env-1 is higher than 12.00%. Current value is {{ $value }}%.
+  - name: merlin_project-1_model-1_env-1
+    rules:
+      - alert: "[merlin] model-1: Throughput warning"
+        expr: |-
+          round(sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m])), 0.001) < 1
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: warning
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: Throughput (RPM) of model-1 model in env-1 is less than 1.00. Current value is {{ $value }}.
+      - alert: "[merlin] model-1: Throughput critical"
+        expr: |-
+          round(sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m])), 0.001) < 2
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: critical
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: Throughput (RPM) of model-1 model in env-1 is less than 2.00. Current value is {{ $value }}.
+      - alert: "[merlin] model-1: 99.00p Latency warning"
+        expr: |-
+          histogram_quantile(0.99, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 3
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: warning
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: 99.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 3.00 ms. Current value is {{ $value }} ms.
+      - alert: "[merlin] model-1: 99.00p Latency critical"
+        expr: |-
+          histogram_quantile(0.99, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 4
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: critical
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: 99.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 4.00 ms. Current value is {{ $value }} ms.
+      - alert: "[merlin] model-1: 95.00p Latency warning"
+        expr: |-
+          histogram_quantile(0.95, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 5
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: warning
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: 95.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 5.00 ms. Current value is {{ $value }} ms.
+      - alert: "[merlin] model-1: 95.00p Latency critical"
+        expr: |-
+          histogram_quantile(0.95, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 6
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: critical
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: 95.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 6.00 ms. Current value is {{ $value }} ms.
+      - alert: "[merlin] model-1: Error Rate warning"
+        expr: |-
+          (100 * sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",response_code_class!="2xx",revision_name=~".*model-1.*"}[1m])) / sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 7
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: warning
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: Error rate of model-1 model in env-1 is higher than 7.00%. Current value is {{ $value }}%.
+      - alert: "[merlin] model-1: Error Rate critical"
+        expr: |-
+          (100 * sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",response_code_class!="2xx",revision_name=~".*model-1.*"}[1m])) / sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 8
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: critical
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: Error rate of model-1 model in env-1 is higher than 8.00%. Current value is {{ $value }}%.
+      - alert: "[merlin] model-1: Cpu warning"
+        expr: |-
+          (100 * sum(rate(container_cpu_usage_seconds_total{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}[1m])) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="cpu"})) > 9
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: warning
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: CPU usage of model-1 model in env-1 is higher than 9.00%. Current value is {{ $value }}%.
+      - alert: "[merlin] model-1: Cpu critical"
+        expr: |-
+          (100 * sum(rate(container_cpu_usage_seconds_total{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}[1m])) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="cpu"})) > 10
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: critical
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: CPU usage of model-1 model in env-1 is higher than 10.00%. Current value is {{ $value }}%.
+      - alert: "[merlin] model-1: Memory warning"
+        expr: |-
+          (100 * sum(container_memory_usage_bytes{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="memory"})) > 11
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: warning
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: Memory usage of model-1 model in env-1 is higher than 11.00%. Current value is {{ $value }}%.
+      - alert: "[merlin] model-1: Memory critical"
+        expr: |-
+          (100 * sum(container_memory_usage_bytes{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="memory"})) > 12
+        for: 5m
+        labels:
+          owner: team-1
+          service_name: merlin_project-1_model-1_env-1
+          severity: critical
+        annotations:
+          dashboard: http://dashboard.dev/?var-cluster=cluster-1&var-model=model-1&var-project=project-1
+          playbook: TODO
+          summary: Memory usage of model-1 model in env-1 is higher than 12.00%. Current value is {{ $value }}%.

--- a/api/service/testdata/model_endpoint_alert.yaml
+++ b/api/service/testdata/model_endpoint_alert.yaml
@@ -111,7 +111,7 @@ groups:
             summary: CPU usage of model-1 model in env-1 is higher than 9.00%. Current value is {{ $value }}%.
         - alert: "[merlin] model-1: Cpu critical"
           expr: |-
-            (100 * sum(rate(container_cpu_usage_seconds_total{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}[1m])) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="cpu")) > 10
+            (100 * sum(rate(container_cpu_usage_seconds_total{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*"}[1m])) / sum(kube_pod_container_resource_requests{cluster_name="cluster-1",container!~"|POD",namespace="project-1",pod=~".*model-1.*",resource="cpu"})) > 10
           for: 5m
           labels:
             owner: team-1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Our alert relies on deprecated metrics that are removed in newer version of kube-state-metrics.

```
kube_pod_container_resource_requests_cpu_cores		-> kube_pod_container_resource_requests{resource="cpu"}
kube_pod_container_resource_requests_memory_bytes 	-> kube_pod_container_resource_requests{resource="memory"}
```