### PR TITLE
Fix baseJson handling in json_output_op

### DIFF
--- a/api/pkg/transformer/pipeline/json_output_op.go
+++ b/api/pkg/transformer/pipeline/json_output_op.go
@@ -2,14 +2,13 @@ package pipeline
 
 import (
 	"context"
-
-	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/gojek/merlin/pkg/transformer/spec"
 	"github.com/gojek/merlin/pkg/transformer/types"
 	"github.com/gojek/merlin/pkg/transformer/types/series"
 	"github.com/gojek/merlin/pkg/transformer/types/table"
+	"github.com/opentracing/opentracing-go"
 )
 
 type JsonOutputOp struct {
@@ -114,9 +113,12 @@ func (j JsonOutputOp) createBaseJsonOutput(env *Environment, baseJson *spec.Base
 		return nil, err
 	}
 
-	jsonOutput, ok := jsonObj.(map[string]interface{})
-	if !ok {
+	switch v := jsonObj.(type) {
+	case types.JSONObject:
+		return v, nil
+	case map[string]interface{}:
+		return types.JSONObject(v), nil
+	default:
 		return nil, errors.New("value in jsonpath must be object")
 	}
-	return types.JSONObject(jsonOutput), nil
 }

--- a/api/pkg/transformer/pipeline/testdata/valid_passthrough.yaml
+++ b/api/pkg/transformer/pipeline/testdata/valid_passthrough.yaml
@@ -1,0 +1,13 @@
+transformerConfig:
+  preprocess:
+    outputs:
+      - jsonOutput:
+          jsonTemplate:
+            baseJson:
+              jsonPath: $.raw_request
+  postprocess:
+    outputs:
+      - jsonOutput:
+          jsonTemplate:
+            baseJson:
+              jsonPath: $.model_response


### PR DESCRIPTION
Signed-off-by: Pradithya Aria <pradithya.pura@go-jek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Fix handling of `baseJson`  in json output op due to incorrect type casting. `evalJSONPath` can return json object as `map[string]interface{}` and `types.JsonPath`  types. Both must be handled properly. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
