### PR TITLE
Add Workflow to Trigger Remote Sync of Docs to caraml-dev/docs via Github Action

### DIFF
--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -27,7 +27,7 @@ jobs:
     #       })
       - uses: actions/checkout@v3
       - id: trigger-caraml
-        uses: actions/trigger-doc-pull
+        uses: caraml-dev/docs/.github/actions/trigger-doc-pull@sync
         with:
           who-to-greet: 'Mona the Octocat'
       - run: echo random-number ${{ steps.trigger-caraml.outputs.random-number }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -24,4 +24,10 @@ jobs:
             repo: 'docs',
             workflow_id: 'pull_docs.yml',
             ref: 'main'
+            inputs: {
+              module: 'model'
+              git-https: 'https://github.com/gojek/merlin.git'
+              doc-folder: 'docs'
+              branch: 'main'
+            }
           })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -20,5 +20,6 @@ jobs:
           module: 'model'
           git_https: 'https://github.com/gojek/merlin.git'
           doc_folder: 'docs'
-          branch: ${{ github.sha }}
+          ref_name: ${{ github.ref_name }}
+          ref_type: ${{ github.ref_type }}
           credentials: ${{ secrets.CARAML_SYNC }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -15,27 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # - uses: actions/github-script@v6
-    #   with:
-    #     github-token: ${{ secrets.CARAML_SYNC }}
-    #     script: |
-    #       await github.rest.actions.createWorkflowDispatch({
-    #         owner: 'caraml-dev',
-    #         repo: 'docs',
-    #         workflow_id: 'test_pull_docs.yml',
-    #         ref: 'main'
-    #       })
-      - uses: actions/checkout@v3
-      - name: checkout caraml actions
-        uses: actions/checkout@v3
-        with:
-          repository: caraml-dev/docs
-          path: caraml-docs
-          ref: 'sync'
-          token: ${{ secrets.CARAML_SYNC }}
-      - id: trigger-caraml
-        uses: ./caraml-docs/.github/actions/trigger-doc-pull
-        with:
-          who-to-greet: 'Mona the Octocat'
-      - run: echo random-number ${{ steps.trigger-caraml.outputs.random-number }}
-        shell: bash
+    - uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.CARAML_SYNC }}
+        script: |
+          await github.rest.actions.createWorkflowDispatch({
+            owner: 'caraml-dev',
+            repo: 'docs',
+            workflow_id: 'pull_docs.yml',
+            ref: 'sync'
+          })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -29,8 +29,9 @@ jobs:
       - name: checkout caraml actions
         uses: actions/checkout@v3
         with:
-          repository: caraml-dev/docs:sync
+          repository: caraml-dev/docs
           path: .github/actions
+          ref: 'sync'
           token: ${{ secrets.CARAML_SYNC }}
       - id: trigger-caraml
         uses: ./.github/actions/trigger-doc-pull/action.yml

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -32,7 +32,7 @@ jobs:
     #         },
     #       })#
     name: Pull Docs CI
-    uses: caraml-dev/docs/.github/template/trigger-caraml-doc-sync.yml@main
+    uses: caraml-dev/docs/.github/workflows/trigger-pull-docs.yml@main
     secrets:
       github-token: ${{ secrets.CARAML_SYNC }}
     with:

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -30,11 +30,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: caraml-dev/docs
-          path: .github/actions
+          path: caraml-docs
           ref: 'sync'
           token: ${{ secrets.CARAML_SYNC }}
       - id: trigger-caraml
-        uses: ./.github/actions/trigger-doc-pull
+        uses: ./caraml-docs/.github/actions/trigger-doc-pull
         with:
           who-to-greet: 'Mona the Octocat'
       - run: echo random-number ${{ steps.trigger-caraml.outputs.random-number }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -20,5 +20,5 @@ jobs:
           module: 'model'
           git_https: 'https://github.com/gojek/merlin.git'
           doc_folder: 'docs'
-          branch: 'main'
+          branch: ${{ github.ref }}
           credentials: ${{ secrets.CARAML_SYNC }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -33,10 +33,9 @@ jobs:
     #       })
     name: Pull Docs CI
     uses: caraml-dev/docs/.github/workflows/trigger-pull-docs.yml@main
-    secrets:
-      token: ${{ secrets.CARAML_SYNC }}
     with:
       module: 'model'
       git_https: 'https://github.com/gojek/merlin.git'
       doc_folder: 'docs'
       branch: 'main'
+      token: ${{ secrets.CARAML_SYNC }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -1,0 +1,27 @@
+# This workflow triggers update in caraml doc
+
+name: Trigger Caraml doc update
+
+on:
+  push:
+    branches: 
+    - git-sync 
+    tags:
+    - v*
+  pull_request:
+
+jobs:
+  trigger-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.CARAML_SYNC }}
+        script: |
+          await github.rest.actions.createWorkflowDispatch({
+            owner: 'caraml-dev',
+            repo: 'caraml-dev/docs',
+            workflow_id: 'test_pull_docs.yml',
+            ref: 'main'
+          })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -26,6 +26,8 @@ jobs:
     #         ref: 'main'
     #       })
       - uses: actions/checkout@v3
+      - name: checkout caraml actions
+        uses: actions/checkout@v3
         with:
           repository: caraml-dev/docs
           path: .github/actions

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -5,7 +5,7 @@ name: Trigger Caraml doc update
 on:
   push:
     branches: 
-    - git-sync 
+    - main 
     tags:
     - v*
   pull_request:

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -29,11 +29,11 @@ jobs:
       - name: checkout caraml actions
         uses: actions/checkout@v3
         with:
-          repository: caraml-dev/docs
+          repository: caraml-dev/docs:sync
           path: .github/actions
           token: ${{ secrets.CARAML_SYNC }}
       - id: trigger-caraml
-        uses: ./.github/actions/trigger-doc-pull/action.yml@sync
+        uses: ./.github/actions/trigger-doc-pull/action.yml
         with:
           who-to-greet: 'Mona the Octocat'
       - run: echo random-number ${{ steps.trigger-caraml.outputs.random-number }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -12,22 +12,30 @@ on:
 
 jobs:
   trigger-sync:
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.CARAML_SYNC }}
-        script: |
-          await github.rest.actions.createWorkflowDispatch({
-            owner: 'caraml-dev',
-            repo: 'docs',
-            workflow_id: 'pull_docs.yml',
-            ref: 'main',
-            inputs: {
-              module: 'model',
-              git_https: 'https://github.com/gojek/merlin.git',
-              doc_folder: 'docs',
-              branch: 'main',
-            },
-          })
+    # steps:
+    # - uses: actions/github-script@v6
+    #   with:
+    #     github-token: ${{ secrets.CARAML_SYNC }}
+    #     script: |
+    #       await github.rest.actions.createWorkflowDispatch({
+    #         owner: 'caraml-dev',
+    #         repo: 'docs',
+    #         workflow_id: 'pull_docs.yml',
+    #         ref: 'main',
+    #         inputs: {
+    #           module: 'model',
+    #           git_https: 'https://github.com/gojek/merlin.git',
+    #           doc_folder: 'docs',
+    #           branch: 'main',
+    #         },
+    #       })
+    uses: caraml/docs/.github/workflows/pull_docs.yml@master
+    secrets:
+      github-token: ${{ secrets.CARAML_SYNC }}
+    with:
+      module: 'model'
+      git_https: 'https://github.com/gojek/merlin.git'
+      doc_folder: 'docs'
+      branch: 'main'

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -34,7 +34,7 @@ jobs:
           ref: 'sync'
           token: ${{ secrets.CARAML_SYNC }}
       - id: trigger-caraml
-        uses: ./.github/actions/trigger-doc-pull/action.yml
+        uses: ./.github/actions/trigger-doc-pull
         with:
           who-to-greet: 'Mona the Octocat'
       - run: echo random-number ${{ steps.trigger-caraml.outputs.random-number }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -21,3 +21,4 @@ jobs:
           git_https: 'https://github.com/gojek/merlin.git'
           doc_folder: 'docs'
           branch: 'main'
+          credentials: ${{ secrets.CARAML_SYNC }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -12,10 +12,12 @@ on:
 
 jobs:
   trigger-sync:
-    name: Pull Docs CI
-    uses: caraml-dev/docs/.github/actions/trigger-pull-docs.yml@sync-action
-    with:
-      module: 'model'
-      git_https: 'https://github.com/gojek/merlin.git'
-      doc_folder: 'docs'
-      branch: 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Remote Doc Pull Workflow
+        uses: caraml-dev/docs/.github/actions/trigger-pull-docs.yml@sync-action
+        with:
+          module: 'model'
+          git_https: 'https://github.com/gojek/merlin.git'
+          doc_folder: 'docs'
+          branch: 'main'

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -20,5 +20,5 @@ jobs:
           module: 'model'
           git_https: 'https://github.com/gojek/merlin.git'
           doc_folder: 'docs'
-          branch: ${{ github.ref }}
+          branch: ${{ github.sha }}
           credentials: ${{ secrets.CARAML_SYNC }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -23,5 +23,5 @@ jobs:
             owner: 'caraml-dev',
             repo: 'docs',
             workflow_id: 'test_pull_docs.yml',
-            ref: 'sync'
+            ref: 'main'
           })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -32,7 +32,7 @@ jobs:
     #         },
     #       })#
     name: Pull Docs CI
-    uses: caraml-dev/docs/.github/workflows/pull_docs.yml@main
+    uses: caraml-dev/docs/.github/template/trigger-caraml-doc-sync.yml@main
     secrets:
       github-token: ${{ secrets.CARAML_SYNC }}
     with:

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Remote Doc Pull Workflow
-        uses: caraml-dev/docs/.github/actions/trigger-pull-docs.yml@sync-action
+        uses: caraml-dev/docs/.github/actions/trigger-pull-docs@sync-action
         with:
           module: 'model'
           git_https: 'https://github.com/gojek/merlin.git'

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -25,9 +25,9 @@ jobs:
             workflow_id: 'pull_docs.yml',
             ref: 'main',
             inputs: {
-              module: 'model'
-              git-https: 'https://github.com/gojek/merlin.git'
-              doc-folder: 'docs'
-              branch: 'main'
+              module: 'model',
+              git-https: 'https://github.com/gojek/merlin.git',
+              doc-folder: 'docs',
+              branch: 'main',
             },
           })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -31,7 +31,8 @@ jobs:
     #           branch: 'main',
     #         },
     #       })
-    uses: caraml-dev/docs/.github/workflows/pull_docs.yml@master
+    name: Pull Docs CI
+    uses: caraml-dev/docs/.github/workflows/pull_docs.yml@main
     secrets:
       github-token: ${{ secrets.CARAML_SYNC }}
     with:

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -34,7 +34,7 @@ jobs:
     name: Pull Docs CI
     uses: caraml-dev/docs/.github/workflows/trigger-pull-docs.yml@main
     secrets:
-      github-token: ${{ secrets.CARAML_SYNC }}
+      token: ${{ secrets.CARAML_SYNC }}
     with:
       module: 'model'
       git_https: 'https://github.com/gojek/merlin.git'

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -29,7 +29,7 @@ jobs:
     #           git_https: 'https://github.com/gojek/merlin.git',
     #           doc_folder: 'docs',
     #           branch: 'main',
-    #         },
+    #         },#
     #       })
     name: Pull Docs CI
     uses: caraml-dev/docs/.github/workflows/trigger-pull-docs.yml@main

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -21,7 +21,7 @@ jobs:
         script: |
           await github.rest.actions.createWorkflowDispatch({
             owner: 'caraml-dev',
-            repo: 'caraml-dev/docs',
+            repo: 'docs',
             workflow_id: 'test_pull_docs.yml',
             ref: 'main'
           })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -33,9 +33,10 @@ jobs:
     #       })
     name: Pull Docs CI
     uses: caraml-dev/docs/.github/workflows/trigger-pull-docs.yml@main
+    secrets:
+      CARAML_SYNC: ${{ secrets.CARAML_SYNC }}
     with:
       module: 'model'
       git_https: 'https://github.com/gojek/merlin.git'
       doc_folder: 'docs'
       branch: 'main'
-      token: ${{ secrets.CARAML_SYNC }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -28,6 +28,6 @@ jobs:
               module: 'model',
               git_https: 'https://github.com/gojek/merlin.git',
               doc_folder: 'docs',
-              branch: 'git-sync',
+              branch: 'main',
             },
           })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -28,6 +28,6 @@ jobs:
               module: 'model',
               git_https: 'https://github.com/gojek/merlin.git',
               doc_folder: 'docs',
-              branch: 'main',
+              branch: 'git-sync',
             },
           })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -4,11 +4,8 @@ name: Trigger CaraML Docs Sync
 
 on:
   push:
-    branches: 
-    - main 
     tags:
     - v*
-  pull_request:
 
 jobs:
   trigger-sync:

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -22,6 +22,6 @@ jobs:
           await github.rest.actions.createWorkflowDispatch({
             owner: 'caraml-dev',
             repo: 'docs',
-            workflow_id: 'pull_docs.yml',
+            workflow_id: 'test_pull_docs.yml',
             ref: 'sync'
           })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -22,6 +22,6 @@ jobs:
           await github.rest.actions.createWorkflowDispatch({
             owner: 'caraml-dev',
             repo: 'docs',
-            workflow_id: 'test_pull_docs.yml',
+            workflow_id: 'pull_docs.yml',
             ref: 'main'
           })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -12,29 +12,8 @@ on:
 
 jobs:
   trigger-sync:
-    # runs-on: ubuntu-latest
-
-    # steps:
-    # - uses: actions/github-script@v6
-    #   with:
-    #     github-token: ${{ secrets.CARAML_SYNC }}
-    #     script: |
-    #       await github.rest.actions.createWorkflowDispatch({
-    #         owner: 'caraml-dev',
-    #         repo: 'docs',
-    #         workflow_id: 'pull_docs.yml',
-    #         ref: 'main',
-    #         inputs: {
-    #           module: 'model',
-    #           git_https: 'https://github.com/gojek/merlin.git',
-    #           doc_folder: 'docs',
-    #           branch: 'main',
-    #         },
-    #       })
     name: Pull Docs CI
-    uses: caraml-dev/docs/.github/workflows/trigger-pull-docs.yml@main
-    secrets:
-      CARAML_SYNC: ${{ secrets.CARAML_SYNC }}
+    uses: caraml-dev/docs/.github/actions/trigger-pull-docs.yml@sync-action
     with:
       module: 'model'
       git_https: 'https://github.com/gojek/merlin.git'

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -30,7 +30,7 @@ jobs:
     #           doc_folder: 'docs',
     #           branch: 'main',
     #         },
-    #       })#
+    #       })
     name: Pull Docs CI
     uses: caraml-dev/docs/.github/workflows/trigger-pull-docs.yml@main
     secrets:

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -26,8 +26,8 @@ jobs:
             ref: 'main',
             inputs: {
               module: 'model',
-              git-https: 'https://github.com/gojek/merlin.git',
-              doc-folder: 'docs',
+              git_https: 'https://github.com/gojek/merlin.git',
+              doc_folder: 'docs',
               branch: 'main',
             },
           })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -15,13 +15,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.CARAML_SYNC }}
-        script: |
-          await github.rest.actions.createWorkflowDispatch({
-            owner: 'caraml-dev',
-            repo: 'docs',
-            workflow_id: 'test_pull_docs.yml',
-            ref: 'main'
-          })
+    # - uses: actions/github-script@v6
+    #   with:
+    #     github-token: ${{ secrets.CARAML_SYNC }}
+    #     script: |
+    #       await github.rest.actions.createWorkflowDispatch({
+    #         owner: 'caraml-dev',
+    #         repo: 'docs',
+    #         workflow_id: 'test_pull_docs.yml',
+    #         ref: 'main'
+    #       })
+      - uses: actions/checkout@v3
+      - id: trigger-caraml
+        uses: actions/trigger-doc-pull
+        with:
+          who-to-greet: 'Mona the Octocat'
+      - run: echo random-number ${{ steps.trigger-caraml.outputs.random-number }}
+        shell: bash

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -31,7 +31,7 @@ jobs:
     #           branch: 'main',
     #         },
     #       })
-    uses: caraml/docs/.github/workflows/pull_docs.yml@master
+    uses: caraml-dev/docs/.github/workflows/pull_docs.yml@master
     secrets:
       github-token: ${{ secrets.CARAML_SYNC }}
     with:

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -23,11 +23,11 @@ jobs:
             owner: 'caraml-dev',
             repo: 'docs',
             workflow_id: 'pull_docs.yml',
-            ref: 'main'
+            ref: 'main',
             inputs: {
               module: 'model'
               git-https: 'https://github.com/gojek/merlin.git'
               doc-folder: 'docs'
               branch: 'main'
-            }
+            },
           })

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -29,7 +29,7 @@ jobs:
     #           git_https: 'https://github.com/gojek/merlin.git',
     #           doc_folder: 'docs',
     #           branch: 'main',
-    #         },#
+    #         },
     #       })
     name: Pull Docs CI
     uses: caraml-dev/docs/.github/workflows/trigger-pull-docs.yml@main

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -26,8 +26,12 @@ jobs:
     #         ref: 'main'
     #       })
       - uses: actions/checkout@v3
+        with:
+          repository: caraml-dev/docs
+          path: .github/actions
+          token: ${{ secrets.CARAML_SYNC }}
       - id: trigger-caraml
-        uses: caraml-dev/docs/.github/actions/trigger-doc-pull@sync
+        uses: ./.github/actions/trigger-doc-pull@sync
         with:
           who-to-greet: 'Mona the Octocat'
       - run: echo random-number ${{ steps.trigger-caraml.outputs.random-number }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -30,7 +30,7 @@ jobs:
     #           doc_folder: 'docs',
     #           branch: 'main',
     #         },
-    #       })
+    #       })#
     name: Pull Docs CI
     uses: caraml-dev/docs/.github/workflows/pull_docs.yml@main
     secrets:

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -33,7 +33,7 @@ jobs:
           path: .github/actions
           token: ${{ secrets.CARAML_SYNC }}
       - id: trigger-caraml
-        uses: ./.github/actions/trigger-doc-pull@sync
+        uses: ./.github/actions/trigger-doc-pull/action.yml@sync
         with:
           who-to-greet: 'Mona the Octocat'
       - run: echo random-number ${{ steps.trigger-caraml.outputs.random-number }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -1,6 +1,6 @@
-# This workflow triggers update in caraml doc
+# This workflow triggers sync of docs to caraml-dev/docs
 
-name: Trigger Caraml doc update
+name: Trigger CaraML Docs Sync
 
 on:
   push:
@@ -14,8 +14,8 @@ jobs:
   trigger-sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Remote Doc Pull Workflow
-        uses: caraml-dev/docs/.github/actions/trigger-pull-docs@sync-action
+      - name: Trigger Remote Doc Sync Workflow
+        uses: caraml-dev/docs/.github/actions/trigger-remote-docs-sync@main
         with:
           module: 'model'
           git_https: 'https://github.com/gojek/merlin.git'


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to sync our docs with caraml gitbook, we add a workflow that will be triggered with PR commits, Merge or Tag in Merlin. This workflow will request caraml docs repo to pull any changes in the doc folder of Merlin.

**Does this PR introduce a user-facing change?**:
No

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
