### PR TITLE
Fix column type where all the value in a column is null

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -194,7 +194,7 @@ require (
 )
 
 replace (
-	github.com/go-gota/gota => github.com/gojekfarm/gota v0.12.1-0.20220329041038-bdee6822d003
+	github.com/go-gota/gota => github.com/gojekfarm/gota v0.12.1-0.20220728030132-6dc5095da912
 	github.com/gojek/merlin-pyspark-app => ../python/batch-predictor
 	github.com/googleapis/gnostic => github.com/google/gnostic v0.5.5
 	github.com/prometheus/tsdb => github.com/prometheus/tsdb v0.3.1

--- a/api/go.sum
+++ b/api/go.sum
@@ -714,8 +714,8 @@ github.com/gojek/mlp v0.0.0-20201002030420-4e35e69a9ab8 h1:S0k9mBbISxJGRUYetI+IK
 github.com/gojek/mlp v0.0.0-20201002030420-4e35e69a9ab8/go.mod h1:IjQCiAzap7TZRZVZ4r2RdzVTuAzoyR5el2GgEu2X1FM=
 github.com/gojek/valkyrie v0.0.0-20180215180059-6aee720afcdf h1:5xRGbUdOmZKoDXkGx5evVLehuCMpuO1hl701bEQqXOM=
 github.com/gojek/valkyrie v0.0.0-20180215180059-6aee720afcdf/go.mod h1:QzhUKaYKJmcbTnCYCAVQrroCOY7vOOI8cSQ4NbuhYf0=
-github.com/gojekfarm/gota v0.12.1-0.20220329041038-bdee6822d003 h1:P9ph+Dcd7xMe/GQ9k24T9NqVS6HRyrNqyscpV0HUBtM=
-github.com/gojekfarm/gota v0.12.1-0.20220329041038-bdee6822d003/go.mod h1:0N1RwZc60ImjH0LMLUTDCvPWdtxk419HJScoigjR66k=
+github.com/gojekfarm/gota v0.12.1-0.20220728030132-6dc5095da912 h1:eIj+404peItzWE1lauPEXdJDKXy+EK3AHfpq1eSTrWg=
+github.com/gojekfarm/gota v0.12.1-0.20220728030132-6dc5095da912/go.mod h1:0N1RwZc60ImjH0LMLUTDCvPWdtxk419HJScoigjR66k=
 github.com/gojekfarm/jsonpath v0.1.1 h1:6GPJ+dBF6pPAQ536FmZw6trUD8uMXEeK//LZ7icgIy0=
 github.com/gojekfarm/jsonpath v0.1.1/go.mod h1:1cPoGRnDKrtGXzs4z/IkEPosicPFZ0Drn2prBo7cyHM=
 github.com/golang-migrate/migrate/v4 v4.11.0 h1:uqtd0ysK5WyBQ/T1K2uDIooJV0o2Obt6uPwP062DupQ=

--- a/api/pkg/transformer/feast/call.go
+++ b/api/pkg/transformer/feast/call.go
@@ -32,6 +32,33 @@ type call struct {
 	valueMonitoringEnabled  bool
 }
 
+func newCall(
+	fr *FeastRetriever,
+	featureTableSpec *spec.FeatureTable,
+	columns []string,
+	entitySet map[string]bool,
+) (*call, error) {
+	feastClient, err := fr.getFeastClient(featureTableSpec.Source)
+	if err != nil {
+		return nil, err
+	}
+	return &call{
+		featureTableSpec:  featureTableSpec,
+		defaultValues:     fr.defaultValues,
+		columns:           columns,
+		entitySet:         entitySet,
+		columnTypeMapping: getFeatureTypeMapping(featureTableSpec),
+
+		feastClient:   feastClient,
+		servingSource: featureTableSpec.Source,
+
+		logger: fr.logger,
+
+		statusMonitoringEnabled: fr.options.StatusMonitoringEnabled,
+		valueMonitoringEnabled:  fr.options.ValueMonitoringEnabled,
+	}, nil
+}
+
 // do create request to feast and return the result as table
 func (fc *call) do(ctx context.Context, entityList []feast.Row, features []string) callResult {
 	tableName := GetTableName(fc.featureTableSpec)

--- a/api/pkg/transformer/feast/call.go
+++ b/api/pkg/transformer/feast/call.go
@@ -17,10 +17,11 @@ import (
 )
 
 type call struct {
-	featureTableSpec *spec.FeatureTable
-	columns          []string
-	entitySet        map[string]bool
-	defaultValues    defaultValues
+	featureTableSpec  *spec.FeatureTable
+	columns           []string
+	entitySet         map[string]bool
+	defaultValues     defaultValues
+	columnTypeMapping map[string]types.ValueType_Enum
 
 	feastClient   StorageClient
 	servingSource spec.ServingSource
@@ -81,7 +82,6 @@ func (fc *call) processResponse(feastResponse *feast.OnlineFeaturesResponse) (*i
 	entities := make([]feast.Row, len(responseRows))
 	valueRows := make([]transTypes.ValueRow, len(responseRows))
 	columnTypes := make([]types.ValueType_Enum, len(fc.columns))
-	columnTypeMapping := getFeatureTypeMapping(fc.featureTableSpec)
 
 	for rowIdx, feastRow := range responseRows {
 		valueRow := make(transTypes.ValueRow, len(fc.columns))
@@ -102,7 +102,7 @@ func (fc *call) processResponse(feastResponse *feast.OnlineFeaturesResponse) (*i
 				}
 			case serving.GetOnlineFeaturesResponse_NOT_FOUND, serving.GetOnlineFeaturesResponse_NULL_VALUE, serving.GetOnlineFeaturesResponse_OUTSIDE_MAX_AGE:
 				if columnTypes[colIdx] == types.ValueType_INVALID {
-					columnTypes[colIdx] = columnTypeMapping[column]
+					columnTypes[colIdx] = fc.columnTypeMapping[column]
 				}
 				defVal, ok := fc.defaultValues.GetDefaultValue(fc.featureTableSpec.Project, column)
 				if !ok {

--- a/api/pkg/transformer/feast/call_test.go
+++ b/api/pkg/transformer/feast/call_test.go
@@ -328,10 +328,10 @@ func TestCall_do(t *testing.T) {
 					columnTypes: []types.ValueType_Enum{
 						types.ValueType_STRING,
 						types.ValueType_STRING,
-						types.ValueType_INVALID,
-						types.ValueType_INVALID,
-						types.ValueType_INVALID,
-						types.ValueType_INVALID,
+						types.ValueType_INT64,
+						types.ValueType_INT64,
+						types.ValueType_INT64,
+						types.ValueType_INT64,
 					},
 					valueRows: transTypes.ValueRows{
 						transTypes.ValueRow{

--- a/api/pkg/transformer/feast/call_test.go
+++ b/api/pkg/transformer/feast/call_test.go
@@ -478,6 +478,7 @@ func TestCall_do(t *testing.T) {
 				logger:                  tt.fields.logger,
 				statusMonitoringEnabled: tt.fields.statusMonitoringEnabled,
 				valueMonitoringEnabled:  tt.fields.valueMonitoringEnabled,
+				columnTypeMapping:       getFeatureTypeMapping(tt.fields.featureTableSpec),
 			}
 
 			fc.feastClient.(*feastmocks.Client).

--- a/api/pkg/transformer/feast/feature_retriever.go
+++ b/api/pkg/transformer/feast/feature_retriever.go
@@ -215,10 +215,11 @@ func (fr *FeastRetriever) newCall(featureTableSpec *spec.FeatureTable, columns [
 	}
 
 	return &call{
-		featureTableSpec: featureTableSpec,
-		defaultValues:    fr.defaultValues,
-		columns:          columns,
-		entitySet:        entitySet,
+		featureTableSpec:  featureTableSpec,
+		defaultValues:     fr.defaultValues,
+		columns:           columns,
+		entitySet:         entitySet,
+		columnTypeMapping: getFeatureTypeMapping(featureTableSpec),
 
 		feastClient:   feastClient,
 		servingSource: featureTableSpec.Source,

--- a/api/pkg/transformer/feast/feature_retriever.go
+++ b/api/pkg/transformer/feast/feature_retriever.go
@@ -208,29 +208,6 @@ func (fr *FeastRetriever) buildEntityRows(symbolRegistry symbol.Registry, config
 	return uniqueEntities, nil
 }
 
-func (fr *FeastRetriever) newCall(featureTableSpec *spec.FeatureTable, columns []string, entitySet map[string]bool) (*call, error) {
-	feastClient, err := fr.getFeastClient(featureTableSpec.Source)
-	if err != nil {
-		return nil, err
-	}
-
-	return &call{
-		featureTableSpec:  featureTableSpec,
-		defaultValues:     fr.defaultValues,
-		columns:           columns,
-		entitySet:         entitySet,
-		columnTypeMapping: getFeatureTypeMapping(featureTableSpec),
-
-		feastClient:   feastClient,
-		servingSource: featureTableSpec.Source,
-
-		logger: fr.logger,
-
-		statusMonitoringEnabled: fr.options.StatusMonitoringEnabled,
-		valueMonitoringEnabled:  fr.options.ValueMonitoringEnabled,
-	}, nil
-}
-
 func (fr *FeastRetriever) getFeastClient(source spec.ServingSource) (StorageClient, error) {
 	servingSource := source
 	if servingSource == spec.ServingSource_UNKNOWN {
@@ -268,7 +245,7 @@ func (fr *FeastRetriever) getFeatureTable(ctx context.Context, entities []feast.
 		}
 		batchedEntities := entityNotInCache[startIndex:endIndex]
 
-		f, err := fr.newCall(featureTableSpec, columns, entitySet)
+		f, err := newCall(fr, featureTableSpec, columns, entitySet)
 		if err != nil {
 			return nil, err
 		}

--- a/api/pkg/transformer/pipeline/testdata/valid_feast_series_transform_conditional.yaml
+++ b/api/pkg/transformer/pipeline/testdata/valid_feast_series_transform_conditional.yaml
@@ -1,0 +1,128 @@
+transformerConfig:
+  preprocess:
+    inputs:
+      - tables:
+          - name: driver
+            columns:
+              - name: driver_id
+                fromJson:
+                  jsonPath: '$.drivers[*].driver_id'
+              - name: service_type
+                fromJson:
+                  jsonPath: $.service_type
+      - feast:
+          - project: default
+            entities:
+              - name: driver_id
+                valueType: STRING
+                jsonPathConfig:
+                  jsonPath: '$.drivers[*].driver_id'
+            features:
+              - name: >-
+                  all_time_cancellation_rate
+                valueType: DOUBLE
+                defaultValue: '0'
+              - name: >-
+                  all_time_completion_rate
+                valueType: DOUBLE
+                defaultValue: '1'
+            tableName: all_time_rate
+            source: BIGTABLE
+          - project: statistic
+            entities:
+              - name: driver_id
+                valueType: STRING
+                jsonPathConfig:
+                  jsonPath: '$.drivers[*].driver_id'
+            features:
+              - name: >-
+                  average_cancellation_rate
+                valueType: DOUBLE
+                defaultValue: 'NaN'
+              - name: >-
+                  average_completion_rate
+                valueType: DOUBLE
+                defaultValue: 'NaN'
+            tableName: recent_rate
+            source: BIGTABLE
+          - project: service
+            entities:
+              - name: driver_id
+                valueType: STRING
+                jsonPathConfig:
+                  jsonPath: '$.drivers[*].driver_id'
+              - name: service_type
+                valueType: INT64
+                jsonPathConfig:
+                  jsonPath: $.service_type
+            features:
+              - name: >-
+                  service_average_cancellation_rate
+                valueType: DOUBLE
+                defaultValue: 'NaN'
+              - name: >-
+                  service_average_completion_rate
+                valueType: DOUBLE
+                defaultValue: 'NaN'
+            tableName: recent_service_type_rate
+            source: BIGTABLE
+    transformations:
+      - tableTransformation:
+      - tableJoin:
+          leftTable: driver
+          rightTable: all_time_rate
+          outputTable: driver_with_all_time
+          how: LEFT
+          onColumns:
+            - driver_id
+      - tableJoin:
+          leftTable: driver_with_all_time
+          rightTable: recent_rate
+          outputTable: all_recent_rate
+          how: LEFT
+          onColumns:
+            - driver_id
+      - tableJoin:
+          leftTable: all_recent_rate
+          rightTable: recent_service_type_rate
+          outputTable: all_rates
+          how: LEFT
+          onColumns:
+            - driver_id
+            - service_type
+      - tableTransformation:
+          inputTable: all_rates
+          outputTable: temp_final_driver
+          steps:
+          - updateColumns:
+            - column: average_cancellation_rate
+              conditions:
+                - rowSelector: all_rates.Col('average_cancellation_rate') == nil
+                  expression: all_rates.Col('all_time_cancellation_rate')
+          - updateColumns:
+            - column: average_completion_rate
+              conditions:
+                - rowSelector: all_rates.Col('average_completion_rate') == nil
+                  expression: all_rates.Col('all_time_completion_rate')
+      - tableTransformation:
+          inputTable: temp_final_driver
+          outputTable: final_driver
+          steps:
+          - updateColumns:
+            - column: service_average_cancellation_rate
+              conditions:
+                - rowSelector: temp_final_driver.Col('service_average_cancellation_rate') == nil
+                  expression: temp_final_driver.Col('average_cancellation_rate')
+            - column: service_average_completion_rate
+              conditions:
+                - rowSelector: temp_final_driver.Col('service_average_completion_rate') == nil
+                  expression: temp_final_driver.Col('average_completion_rate')
+    outputs:
+      - jsonOutput:
+          jsonTemplate:
+            fields:
+              - fieldName: instances
+                fromTable:
+                  tableName: final_driver
+                  format: RECORD
+  postprocess: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
This PR address several issues that triggered when user try impute `NaN` value from a table by using conditional update. Following are the issues:
* Series/Column that generated by feast input is in string type where the type defined in `featureTableSpec` is double, this is happening because currently we try to infer the type by the value, for this case all the values are `NaN` or `null` so the type can't be inferred and default to string
* Join two table where one of the columns type is string but the value all `NaN` or `null`, internally each column row has `nan` flag to indicate whether the row is `NaN`. For this case affected column in result table doesn't carry `nan` flag, so the filtering or row selection for `NaN` or `null` value won't work as expected since the operation relies on `nan` flag.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

* For case 2 the fix is on the gota library [PR](https://github.com/gojekfarm/gota/pull/3), this PR to update the library version
* For case  1 the fix is to specify column type for features based on the type in given featurespec
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
