### PR TITLE
Add support for more granular configuration of MLP Core API

### DIFF
--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -106,32 +106,20 @@ func main() {
 		http.ServeFile(w, r, cfg.SwaggerPath)
 	})
 
-	reactConfig := cfg.ReactAppConfig
 	uiEnv := uiEnvHandler{
-		OauthClientID:     reactConfig.OauthClientID,
-		Environment:       reactConfig.Environment,
-		SentryDSN:         reactConfig.SentryDSN,
-		DocURL:            reactConfig.DocURL,
-		HomePage:          reactConfig.HomePage,
-		MerlinURL:         reactConfig.MerlinURL,
-		MlpURL:            reactConfig.MlpURL,
-		DockerRegistries:  reactConfig.DockerRegistries,
-		MaxAllowedReplica: reactConfig.MaxAllowedReplica,
+		ReactAppConfig: &cfg.ReactAppConfig,
+
+		AlertEnabled: cfg.FeatureToggleConfig.AlertConfig.AlertEnabled,
 
 		DefaultFeastServingSource: cfg.StandardTransformerConfig.DefaultFeastSource.String(),
 		FeastServingURLs:          cfg.StandardTransformerConfig.FeastServingURLs,
-		FeastCoreURL:              reactConfig.FeastCoreURL,
 
 		MonitoringEnabled:              cfg.FeatureToggleConfig.MonitoringConfig.MonitoringEnabled,
 		MonitoringPredictionJobBaseURL: cfg.FeatureToggleConfig.MonitoringConfig.MonitoringJobBaseURL,
-
-		AlertEnabled: cfg.FeatureToggleConfig.AlertConfig.AlertEnabled,
 	}
 
-	uiHomePage := reactConfig.HomePage
-	if !strings.HasPrefix(uiHomePage, "/") {
-		uiHomePage = "/" + uiEnv.HomePage
-	}
+	uiHomePage := fmt.Sprintf("/%s", strings.TrimPrefix(cfg.ReactAppConfig.HomePage, "/"))
+
 	router.Path(uiHomePage + "/env.js").HandlerFunc(uiEnv.handler)
 
 	ui := uiHandler{staticPath: cfg.UI.StaticPath, indexPath: cfg.UI.IndexPath}

--- a/api/cmd/api/ui_handler.go
+++ b/api/cmd/api/ui_handler.go
@@ -11,19 +11,10 @@ import (
 )
 
 type uiEnvHandler struct {
-	OauthClientID     string                `json:"REACT_APP_OAUTH_CLIENT_ID,omitempty"`
-	Environment       string                `json:"REACT_APP_ENVIRONMENT,omitempty"`
-	SentryDSN         string                `json:"REACT_APP_SENTRY_DSN,omitempty"`
-	DocURL            config.Documentations `json:"REACT_APP_MERLIN_DOCS_URL,omitempty"`
-	HomePage          string                `json:"REACT_APP_HOMEPAGE,omitempty"`
-	MerlinURL         string                `json:"REACT_APP_MERLIN_API,omitempty"`
-	MlpURL            string                `json:"REACT_APP_MLP_API,omitempty"`
-	DockerRegistries  string                `json:"REACT_APP_DOCKER_REGISTRIES,omitempty"`
-	MaxAllowedReplica int                   `json:"REACT_APP_MAX_ALLOWED_REPLICA,omitempty"`
+	*config.ReactAppConfig
 
 	DefaultFeastServingSource string                  `json:"REACT_APP_DEFAULT_FEAST_SOURCE,omitempty"`
 	FeastServingURLs          config.FeastServingURLs `json:"REACT_APP_FEAST_SERVING_URLS,omitempty"`
-	FeastCoreURL              string                  `json:"REACT_APP_FEAST_CORE_API,omitempty"`
 
 	MonitoringEnabled              bool   `json:"REACT_APP_MONITORING_DASHBOARD_ENABLED"`
 	MonitoringPredictionJobBaseURL string `json:"REACT_APP_MONITORING_DASHBOARD_JOB_BASE_URL"`

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -62,18 +62,16 @@ type UIConfig struct {
 }
 
 type ReactAppConfig struct {
-	OauthClientID     string         `envconfig:"REACT_APP_OAUTH_CLIENT_ID"`
-	Environment       string         `envconfig:"REACT_APP_ENVIRONMENT"`
-	SentryDSN         string         `envconfig:"REACT_APP_SENTRY_DSN"`
-	DocURL            Documentations `envconfig:"REACT_APP_MERLIN_DOCS_URL"`
-	AlertEnabled      bool           `envconfig:"REACT_APP_ALERT_ENABLED"`
-	MonitoringEnabled bool           `envconfig:"REACT_APP_MONITORING_DASHBOARD_ENABLED"`
-	HomePage          string         `envconfig:"REACT_APP_HOMEPAGE"`
-	MerlinURL         string         `envconfig:"REACT_APP_MERLIN_API"`
-	MlpURL            string         `envconfig:"REACT_APP_MLP_API"`
-	FeastCoreURL      string         `envconfig:"REACT_APP_FEAST_CORE_API"`
-	DockerRegistries  string         `envconfig:"REACT_APP_DOCKER_REGISTRIES"`
-	MaxAllowedReplica int            `envconfig:"REACT_APP_MAX_ALLOWED_REPLICA" default:"20"`
+	DocURL            Documentations `envconfig:"REACT_APP_MERLIN_DOCS_URL" json:"REACT_APP_MERLIN_DOCS_URL,omitempty"`
+	DockerRegistries  string         `envconfig:"REACT_APP_DOCKER_REGISTRIES" json:"REACT_APP_DOCKER_REGISTRIES,omitempty"`
+	Environment       string         `envconfig:"REACT_APP_ENVIRONMENT" json:"REACT_APP_ENVIRONMENT,omitempty"`
+	FeastCoreURL      string         `envconfig:"REACT_APP_FEAST_CORE_API" json:"REACT_APP_FEAST_CORE_API,omitempty"`
+	HomePage          string         `envconfig:"REACT_APP_HOMEPAGE" json:"REACT_APP_HOMEPAGE,omitempty"`
+	MaxAllowedReplica int            `envconfig:"REACT_APP_MAX_ALLOWED_REPLICA" default:"20" json:"REACT_APP_MAX_ALLOWED_REPLICA,omitempty"`
+	MerlinURL         string         `envconfig:"REACT_APP_MERLIN_API" json:"REACT_APP_MERLIN_API,omitempty"`
+	MlpURL            string         `envconfig:"REACT_APP_MLP_API" json:"REACT_APP_MLP_API,omitempty"`
+	OauthClientID     string         `envconfig:"REACT_APP_OAUTH_CLIENT_ID" json:"REACT_APP_OAUTH_CLIENT_ID,omitempty"`
+	SentryDSN         string         `envconfig:"REACT_APP_SENTRY_DSN" json:"REACT_APP_SENTRY_DSN,omitempty"`
 }
 
 type Documentations []Documentation

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -83,33 +83,29 @@ spec:
           - name: DATABASE_NAME
             value: {{ index .Values "merlin-postgresql" "postgresqlDatabase" }}
           - name: REACT_APP_OAUTH_CLIENT_ID
-            value: "{{ .Values.merlin.oauthClientID }}"
+            value: "{{ .Values.merlin.ui.oauthClientID }}"
           - name: REACT_APP_ENVIRONMENT
             value: "{{ .Values.merlin.environment }}"
           {{- if .Values.merlin.sentry.enabled }}
           - name: REACT_APP_SENTRY_DSN
             value: "{{ .Values.merlin.sentry.dsn }}"
           {{- end }}
-          {{- if .Values.merlin.docsURL }}
+          {{- if .Values.merlin.ui.docsURL }}
           - name: REACT_APP_MERLIN_DOCS_URL
-            value: {{ .Values.merlin.docsURL | toJson | quote }}
+            value: {{ .Values.merlin.ui.docsURL | toJson | quote }}
           {{- end }}
-          - name: REACT_APP_ALERT_ENABLED
-            value: "{{ .Values.merlin.alert.enabled }}"
-          - name: REACT_APP_MONITORING_DASHBOARD_ENABLED
-            value: "{{ .Values.merlin.monitoring.enabled }}"
           - name: REACT_APP_HOMEPAGE
-            value: "{{ .Values.merlin.homepage }}"
+            value: "{{ .Values.merlin.ui.homepage }}"
           - name: REACT_APP_MERLIN_API
-            value: "{{ .Values.merlin.apiHost }}"
+            value: "{{ .Values.merlin.ui.apiHost }}"
           - name: REACT_APP_MLP_API
-            value: "{{ .Values.merlin.mlpApi.apiHost }}"
+            value: "{{ .Values.merlin.ui.mlp.apiHost }}"
           - name: REACT_APP_FEAST_CORE_API
             value: "{{ .Values.merlin.feastCoreApi.apiHost }}"
           - name: REACT_APP_DOCKER_REGISTRIES
-            value: "{{ .Values.merlin.dockerRegistries }}"
+            value: "{{ .Values.merlin.ui.dockerRegistries }}"
           - name: REACT_APP_MAX_ALLOWED_REPLICA
-            value: "{{ .Values.merlin.maxAllowedReplica }}"
+            value: "{{ .Values.merlin.ui.maxAllowedReplica }}"
           - name: IMG_BUILDER_CLUSTER_NAME
             value: "{{ .Values.merlin.imageBuilder.clusterName }}"
           - name: IMG_BUILDER_BUILD_CONTEXT_URI

--- a/charts/merlin/templates/mlflow-deployment.yaml
+++ b/charts/merlin/templates/mlflow-deployment.yaml
@@ -16,9 +16,6 @@ spec:
     matchLabels:
       app: {{ template "mlflow.fullname" . }}
       release: {{ .Release.Name }}
-      {{- if .Values.mlflow.podLabels}}
-        {{- toYaml .Values.mlflow.podLabels | nindent 8 }}
-      {{- end}}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/merlin/templates/mlflow-deployment.yaml
+++ b/charts/merlin/templates/mlflow-deployment.yaml
@@ -29,9 +29,9 @@ spec:
       labels:
         app: {{ template "mlflow.fullname" . }}
         release: {{ .Release.Name }}
-      {{- if .Values.mlflow.podLabels}}
-        {{ toYaml .Values.mlflow.podLabels | nindent 8 }}
-      {{- end}}
+        {{- if .Values.mlflow.podLabels }}
+          {{- toYaml .Values.mlflow.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ template "mlflow.fullname" . }}

--- a/charts/merlin/values-e2e.yaml
+++ b/charts/merlin/values-e2e.yaml
@@ -4,6 +4,10 @@ merlin:
   image:
     repository: merlin
   replicaCount: 1
+
+  podLabels:
+    environment: e2e
+
   resources:
     requests:
       cpu: 25m
@@ -120,6 +124,10 @@ mlflow:
     requests:
       cpu: 25m
       memory: 64Mi
+
+  podLabels:
+    environment: e2e
+
   ingress:
     enabled: true
     class: istio

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -30,23 +30,6 @@ merlin:
 
   environment: dev
 
-  homepage: /merlin
-
-  apiHost: http://merlin.mlp/v1
-
-  docsURL:
-    [
-      {
-        "href": "https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md",
-        "label": "Getting Started with Merlin",
-      },
-    ]
-
-  # Comma-separated value of Docker registries that can be chosen in deployment page
-  dockerRegistries: ghcr.io/gojek,ghcr.io/your-company
-
-  maxAllowedReplica: 20
-
   loggerDestinationURL: "http://yourDestinationLogger"
 
   queue:
@@ -218,6 +201,28 @@ merlin:
   mlflow:
     # This should be the actual DNS registered
     trackingURL: "http://www.example.com"
+
+  ui:
+    oauthClientID: ""
+
+    homepage: /merlin
+
+    apiHost: /api/merlin/v1
+
+    mlp:
+      apiHost: /api/v1
+
+    docsURL: [
+      {
+        "href": "https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md",
+        "label": "Getting Started with Merlin",
+      },
+    ]
+
+    # Comma-separated value of Docker registries that can be chosen in deployment page
+    dockerRegistries: ghcr.io/gojek,ghcr.io/your-company
+
+    maxAllowedReplica: 20
 
 postgresql:
   enabled: true


### PR DESCRIPTION
### Context:

Merlin API depends on MLP Core API for retrieving the list of projects/secrets. Merlin UI also depends on MLP Core API for the same purpose. 

Currently, MLP API URL can only be configured to the same value (e.g http://mlp.example.com/api/v1) for both Merlin API and UI. However, moving forward, we would like to decouple these two values so API and UI can be configured separately. In this case, Merlin UI can use a relative MLP API URL (i.e. `/api/v1`), while Merlin API can call a cluster-local API endpoint (i.e. `http://mlp.mlp.svc.cluster.local:8080/v1`) to bypass authentication policy of MLP API.
