### PR TITLE
Fix autoscaling target value when memory usage is selected as the target metrics

### DIFF
--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-batch-predictor
       - name: Install dependencies
         working-directory: ./python/batch-predictor
         run: |
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-pyfunc-server
       - name: Install dependencies
         working-directory: ./python/pyfunc-server
         run: |
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-python-sdk
       - name: Install dependencies
         working-directory: ./python/sdk
         run: |

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -136,6 +136,8 @@ func (t *InferenceServiceTemplater) CreateInferenceServiceSpec(modelService *mod
 }
 
 func (t *InferenceServiceTemplater) PatchInferenceServiceSpec(orig *kservev1beta1.InferenceService, modelService *models.Service, config *config.DeploymentConfig) (*kservev1beta1.InferenceService, error) {
+	applyDefaults(modelService, config)
+
 	orig.ObjectMeta.Labels = modelService.Metadata.ToLabel()
 	annotations, err := createAnnotations(modelService, config)
 	if err != nil {

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -107,6 +107,8 @@ func NewInferenceServiceTemplater(standardTransformerConfig config.StandardTrans
 }
 
 func (t *InferenceServiceTemplater) CreateInferenceServiceSpec(modelService *models.Service, config *config.DeploymentConfig) (*kservev1beta1.InferenceService, error) {
+	applyDefaults(modelService, config)
+
 	annotations, err := createAnnotations(modelService, config)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create inference service spec: %w", err)
@@ -151,15 +153,6 @@ func (t *InferenceServiceTemplater) PatchInferenceServiceSpec(orig *kservev1beta
 
 func createPredictorSpec(modelService *models.Service, config *config.DeploymentConfig) kservev1beta1.PredictorSpec {
 	envVars := modelService.EnvVars
-
-	if modelService.ResourceRequest == nil {
-		modelService.ResourceRequest = &models.ResourceRequest{
-			MinReplica:    config.DefaultModelResourceRequests.MinReplica,
-			MaxReplica:    config.DefaultModelResourceRequests.MaxReplica,
-			CPURequest:    config.DefaultModelResourceRequests.CPURequest,
-			MemoryRequest: config.DefaultModelResourceRequests.MemoryRequest,
-		}
-	}
 
 	// Set cpu limit and memory limit to be 2x of the requests
 	cpuLimit := modelService.ResourceRequest.CPURequest.DeepCopy()
@@ -286,15 +279,6 @@ func createPredictorSpec(modelService *models.Service, config *config.Deployment
 }
 
 func (t *InferenceServiceTemplater) createTransformerSpec(modelService *models.Service, transformer *models.Transformer, config *config.DeploymentConfig) *kservev1beta1.TransformerSpec {
-	if transformer.ResourceRequest == nil {
-		transformer.ResourceRequest = &models.ResourceRequest{
-			MinReplica:    config.DefaultTransformerResourceRequests.MinReplica,
-			MaxReplica:    config.DefaultTransformerResourceRequests.MaxReplica,
-			CPURequest:    config.DefaultTransformerResourceRequests.CPURequest,
-			MemoryRequest: config.DefaultTransformerResourceRequests.MemoryRequest,
-		}
-	}
-
 	// Set cpu limit and memory limit to be 2x of the requests
 	cpuLimit := transformer.ResourceRequest.CPURequest.DeepCopy()
 	cpuLimit.Add(transformer.ResourceRequest.CPURequest)
@@ -481,13 +465,13 @@ func createAnnotations(modelService *models.Service, config *config.DeploymentCo
 				annotations[knautoscaling.ClassAnnotationKey] = knautoscaling.KPA
 			}
 
-			autoscalingMetrics, err := toKNativeAutoscalerMetrics(modelService.AutoscalingPolicy.MetricsType)
+			autoscalingMetrics, targetValue, err := toKNativeAutoscalerMetrics(modelService.AutoscalingPolicy.MetricsType, modelService.AutoscalingPolicy.TargetValue, modelService.ResourceRequest)
 			if err != nil {
 				return nil, err
 			}
 
 			annotations[knautoscaling.MetricAnnotationKey] = autoscalingMetrics
-			annotations[knautoscaling.TargetAnnotationKey] = fmt.Sprintf("%.0f", modelService.AutoscalingPolicy.TargetValue)
+			annotations[knautoscaling.TargetAnnotationKey] = targetValue
 		}
 	}
 
@@ -619,4 +603,28 @@ func createPyFuncDefaultEnvVars(svc *models.Service) models.EnvVars {
 		},
 	}
 	return envVars
+}
+
+func applyDefaults(service *models.Service, config *config.DeploymentConfig) {
+	// apply default resource request for model
+	if service.ResourceRequest == nil {
+		service.ResourceRequest = &models.ResourceRequest{
+			MinReplica:    config.DefaultModelResourceRequests.MinReplica,
+			MaxReplica:    config.DefaultModelResourceRequests.MaxReplica,
+			CPURequest:    config.DefaultModelResourceRequests.CPURequest,
+			MemoryRequest: config.DefaultModelResourceRequests.MemoryRequest,
+		}
+	}
+
+	// apply default resource request for transformer
+	if service.Transformer != nil && service.Transformer.Enabled {
+		if service.Transformer.ResourceRequest == nil {
+			service.Transformer.ResourceRequest = &models.ResourceRequest{
+				MinReplica:    config.DefaultTransformerResourceRequests.MinReplica,
+				MaxReplica:    config.DefaultTransformerResourceRequests.MaxReplica,
+				CPURequest:    config.DefaultTransformerResourceRequests.CPURequest,
+				MemoryRequest: config.DefaultTransformerResourceRequests.MemoryRequest,
+			}
+		}
+	}
 }

--- a/api/cluster/resource/utils.go
+++ b/api/cluster/resource/utils.go
@@ -2,25 +2,34 @@ package resource
 
 import (
 	"fmt"
+	"math"
 
+	"github.com/gojek/merlin/models"
 	"github.com/gojek/merlin/pkg/autoscaling"
 	"github.com/gojek/merlin/pkg/deployment"
 	kserveconstant "github.com/kserve/kserve/pkg/constants"
+	"k8s.io/apimachinery/pkg/api/resource"
 	knautoscaling "knative.dev/serving/pkg/apis/autoscaling"
 )
 
-func toKNativeAutoscalerMetrics(metricsType autoscaling.MetricsType) (string, error) {
+func toKNativeAutoscalerMetrics(metricsType autoscaling.MetricsType, metricsValue float64, resourceReq *models.ResourceRequest) (string, string, error) {
 	switch metricsType {
 	case autoscaling.CPUUtilization:
-		return knautoscaling.CPU, nil
+		targetValue := fmt.Sprintf("%.0f", metricsValue)
+		return knautoscaling.CPU, targetValue, nil
 	case autoscaling.MemoryUtilization:
-		return knautoscaling.Memory, nil
+		// Calculate memory target value based on memory request * metricsValue
+		// ref: https://github.com/krithika369/turing/blob/6cc3b5f673ccf66e9c1351b2d91382315e86f8ce/api/turing/cluster/knative_service.go#L166
+		memoryTarget := computeResource(resourceReq.MemoryRequest, metricsValue/100)
+		return knautoscaling.Memory, fmt.Sprintf("%.0f", float64(memoryTarget.Value())/math.Pow(1024, 2)), nil
 	case autoscaling.RPS:
-		return knautoscaling.RPS, nil
+		targetValue := fmt.Sprintf("%.0f", metricsValue)
+		return knautoscaling.RPS, targetValue, nil
 	case autoscaling.Concurrency:
-		return knautoscaling.Concurrency, nil
+		targetValue := fmt.Sprintf("%.0f", metricsValue)
+		return knautoscaling.Concurrency, targetValue, nil
 	default:
-		return "", fmt.Errorf("unsuppported autoscaler metrics on serverless deployment: %s", metricsType)
+		return "", "", fmt.Errorf("unsuppported autoscaler metrics on serverless deployment: %s", metricsType)
 	}
 }
 
@@ -42,4 +51,20 @@ func toKServeDeploymentMode(deploymentMode deployment.Mode) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported deployment mode: %s", deploymentMode)
 	}
+}
+
+func computeResource(resourceQuantity resource.Quantity, fraction float64) resource.Quantity {
+	scaledValue := resourceQuantity.Value()
+
+	scaledMilliValue := int64(math.MaxInt64 - 1)
+	if scaledValue < (math.MaxInt64 / 1000) {
+		scaledMilliValue = resourceQuantity.MilliValue()
+	}
+	percentageValue := float64(scaledMilliValue) * fraction
+	newValue := int64(math.MaxInt64)
+	if percentageValue < math.MaxInt64 {
+		newValue = int64(percentageValue)
+	}
+	newquantity := resource.NewMilliQuantity(newValue, resource.BinarySI)
+	return *newquantity
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Knative expect the value of `autoscaling.knative.dev/target` annotation to be in `MiB` units when `autoscaling.knative.dev/metric` is set to memory (i.e. memory-bound autoscaling). 
Existing implementation expect users to provide memory usage target % and pass it directly to knative without conversion. It leads to incorrect behavior, in which the autoscaling target will only vary between 0-100MiB.  
This PR address this bugs by converting the target memory utilization % provided by users to absolute memory requested by using user's requested memory resource. 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix incorrect memory-bound autoscaling behavior
```

**Checklist**

- [X] Added unit test, integration, and/or e2e tests
- [X] Tested locally
- [N.A.] Updated documentation
- [N.A.] Update Swagger spec if the PR introduce API changes
- [N.A.] Regenerated Golang and Python client if the PR introduce API changes
