### PR TITLE
Restore deprecated environment variable for backward compatibility

### DIFF
--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -44,6 +44,7 @@ const (
 	envTransformerModelName  = "MERLIN_TRANSFORMER_MODEL_NAME"
 	envTransformerPredictURL = "MERLIN_TRANSFORMER_MODEL_PREDICT_URL"
 
+	envPyFuncModelName           = "MODEL_NAME"
 	envPredictorPort             = "MERLIN_PREDICTOR_PORT"
 	envPredictorModelName        = "MERLIN_MODEL_NAME"
 	envPredictorArtifactLocation = "MERLIN_ARTIFACT_LOCATION"
@@ -579,6 +580,10 @@ func createCustomPredictorSpec(modelService *models.Service, resources corev1.Re
 // createPyFuncDefaultEnvVars return default env vars for Pyfunc model.
 func createPyFuncDefaultEnvVars(svc *models.Service) models.EnvVars {
 	envVars := models.EnvVars{
+		models.EnvVar{
+			Name:  envPyFuncModelName,
+			Value: models.CreateInferenceServiceName(svc.ModelName, svc.ModelVersion),
+		},
 		models.EnvVar{
 			Name:  envModelName,
 			Value: svc.ModelName,

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -3378,6 +3378,10 @@ func getLimit(quantity resource.Quantity) resource.Quantity {
 func createPyFuncDefaultEnvVarsWithProtocol(svc *models.Service, protocolValue protocol.Protocol) models.EnvVars {
 	envVars := models.EnvVars{
 		models.EnvVar{
+			Name:  envPyFuncModelName,
+			Value: models.CreateInferenceServiceName(svc.ModelName, svc.ModelVersion),
+		},
+		models.EnvVar{
 			Name:  envModelName,
 			Value: svc.ModelName,
 		},

--- a/python/pyfunc-server/base.Dockerfile
+++ b/python/pyfunc-server/base.Dockerfile
@@ -24,3 +24,5 @@ RUN conda env create -f /pyfunc-server/environment.yaml && \
 
 RUN mkdir /prom_dir
 ENV PROMETHEUS_MULTIPROC_DIR=/prom_dir
+# For backward compatibility
+ENV prometheus_multiproc_dir=/prom_dir


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:

`MODEL_NAME` & `prometheus_multiproc_dir` env var was removed in this PR https://github.com/gojek/merlin/pull/276 . However, we'll restore it for now to give time to user for migrating to the new environment variable (CARAML_MODEL_FULLNAME).

<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
