### PR TITLE
Add output and autoload UI standard transformer components for UPI protocol

### DIFF
--- a/api/pkg/transformer/pipeline/compiler.go
+++ b/api/pkg/transformer/pipeline/compiler.go
@@ -245,6 +245,9 @@ func (c *Compiler) doCompilePipeline(pipeline *spec.Pipeline, pipelineType types
 }
 
 func (c *Compiler) parseUpiPreprocessOutput(outputSpec *spec.UPIPreprocessOutput) (Op, error) {
+	if outputSpec.PredictionTableName == "" && len(outputSpec.TransformerInputTableNames) == 0 {
+		return nil, fmt.Errorf(`"predictionTableName" or "transformerInputTableNames" must be set for upi preprocess output spec`)
+	}
 	if outputSpec.PredictionTableName != "" {
 		if err := c.checkVariableRegistered(outputSpec.PredictionTableName); err != nil {
 			return nil, err
@@ -261,6 +264,9 @@ func (c *Compiler) parseUpiPreprocessOutput(outputSpec *spec.UPIPreprocessOutput
 }
 
 func (c *Compiler) parseUpiPostprocessOutput(outputSpec *spec.UPIPostprocessOutput) (Op, error) {
+	if outputSpec.PredictionResultTableName == "" {
+		return nil, fmt.Errorf(`"predictionResultTableName" must be set for upi postprocess output spec`)
+	}
 	if err := c.checkVariableRegistered(outputSpec.PredictionResultTableName); err != nil {
 		return nil, err
 	}

--- a/api/pkg/transformer/pipeline/compiler_test.go
+++ b/api/pkg/transformer/pipeline/compiler_test.go
@@ -139,6 +139,38 @@ func TestCompiler_Compile(t *testing.T) {
 			expError:         errors.New("unable to compile preprocessing pipeline: unknown name var3 (1:1)\n | var3\n | ^"),
 		},
 		{
+			name: "invalid upi preprocess due to empty `predictionTableName` and `transformerInputTableNames`",
+			fields: fields{
+				sr:           symbol.NewRegistry(),
+				feastClients: feast.Clients{},
+				feastOptions: &feast.Options{
+					CacheEnabled:  true,
+					CacheSizeInMB: 100,
+				},
+				logger:   logger,
+				protocol: prt.UpiV1,
+			},
+			specYamlFilePath: "./testdata/upi/invalid_preprocess_output_empty.yaml",
+			wantErr:          true,
+			expError:         errors.New(`unable to compile preprocessing pipeline: "predictionTableName" or "transformerInputTableNames" must be set for upi preprocess output spec`),
+		},
+		{
+			name: "invalid upi postprocess due to empty `predictionResultTableName`",
+			fields: fields{
+				sr:           symbol.NewRegistry(),
+				feastClients: feast.Clients{},
+				feastOptions: &feast.Options{
+					CacheEnabled:  true,
+					CacheSizeInMB: 100,
+				},
+				logger:   logger,
+				protocol: prt.UpiV1,
+			},
+			specYamlFilePath: "./testdata/upi/invalid_postprocess_empty_result_table.yaml",
+			wantErr:          true,
+			expError:         errors.New(`unable to compile postprocessing pipeline: "predictionResultTableName" must be set for upi postprocess output spec`),
+		},
+		{
 			name: "invalid upi preprocess output",
 			fields: fields{
 				sr:           symbol.NewRegistry(),

--- a/api/pkg/transformer/pipeline/testdata/upi/invalid_postprocess_empty_result_table.yaml
+++ b/api/pkg/transformer/pipeline/testdata/upi/invalid_postprocess_empty_result_table.yaml
@@ -1,0 +1,22 @@
+transformerConfig:
+  preprocess:
+    inputs:
+    - variables:
+        - name: country
+          jsonPath: $.prediction_context[0].string_value
+  postprocess:
+    inputs:
+    - autoload:
+        tableNames:
+          - prediction_result
+    transformations:
+    - tableTransformation:
+          inputTable: prediction_result
+          outputTable: output_table
+          steps:
+            - updateColumns:
+                - column: country
+                  expression: country
+    outputs:
+      - upiPostprocessOutput:
+          predictionResultTableName: # failed due to empty result table name

--- a/api/pkg/transformer/pipeline/testdata/upi/invalid_preprocess_output_empty.yaml
+++ b/api/pkg/transformer/pipeline/testdata/upi/invalid_preprocess_output_empty.yaml
@@ -1,0 +1,23 @@
+transformerConfig:
+  preprocess:
+    inputs:
+    - autoload:
+        tableNames:
+          - table1
+          - table2
+          - table3
+        variableNames:
+          - var1
+          - var2
+    transformations:
+      - tableTransformation:
+          inputTable: table2
+          outputTable: output_table
+          steps:
+            - updateColumns:
+              - column: col1
+                expression: var2 
+    outputs:
+      - upiPreprocessOutput: # failed due to empty `predictionTableName` and `transformerInputTableNames`
+          predictionTableName:
+          transformerInputTableNames:

--- a/ui/src/pages/version/components/forms/components/transformer/InputPanel.js
+++ b/ui/src/pages/version/components/forms/components/transformer/InputPanel.js
@@ -11,16 +11,20 @@ import {
 import { get, useOnChangeHandler } from "@gojek/mlp-ui";
 import { AddButton } from "./components/AddButton";
 import { TableInputCard } from "./components/table_inputs/TableInputCard";
+import { AutoloadCard } from "./components/table_inputs/AutoloadCard";
 import { VariablesInputCard } from "./components/table_inputs/VariablesInputCard";
 import { FeastInputGroup } from "../feast_config/components/FeastInputGroup";
 import { EncodersInputGroup } from "./components/table_inputs/EncodersInputGroup";
 import { Panel } from "../Panel";
 import {
+  Autoload,
   FeastInput,
   TablesInput
 } from "../../../../../../services/transformer/TransformerConfig";
 
-export const InputPanel = ({ inputs = [], onChangeHandler, errors = {} }) => {
+import {PROTOCOL} from "../../../../../../services/version_endpoint/VersionEndpoint"
+
+export const InputPanel = ({ inputs = [], onChangeHandler, protocol, errors = {} }) => {
   const { onChange } = useOnChangeHandler(onChangeHandler);
 
   const onAddInput = (field, input) => {
@@ -120,6 +124,16 @@ export const InputPanel = ({ inputs = [], onChangeHandler, errors = {} }) => {
                       />
                     )}
 
+                    {input.autoload && (
+                     <AutoloadCard 
+                      autoload={input.autoload}
+                      onChangeHandler={onChange(`${idx}.autoload`)}
+                      onDelete={onDeleteInput(idx)}
+                      dragHandleProps={provided.dragHandleProps}
+                      errors={errors}
+                     />
+                    )}
+
                     <EuiSpacer size="s" />
                   </EuiFlexItem>
                 )}
@@ -170,7 +184,18 @@ export const InputPanel = ({ inputs = [], onChangeHandler, errors = {} }) => {
                   ])
                 }
               />
-            </EuiFlexItem>
+              </EuiFlexItem>
+              { protocol === PROTOCOL.UPI_V1 && (
+                <EuiFlexItem>
+                  <AddButton
+                    title="+ Add Autoload"
+                    description="Autoload configuration register tables and variables to standard transformer registry"
+                    onClick={() =>
+                      onAddInput("autoload", new Autoload())
+                    }
+                  />
+                </EuiFlexItem>
+              )}
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/ui/src/pages/version/components/forms/components/transformer/InputPanel.js
+++ b/ui/src/pages/version/components/forms/components/transformer/InputPanel.js
@@ -144,6 +144,17 @@ export const InputPanel = ({ inputs = [], onChangeHandler, protocol, errors = {}
 
         <EuiFlexItem>
           <EuiFlexGroup>
+            { protocol === PROTOCOL.UPI_V1 && (
+                <EuiFlexItem>
+                  <AddButton
+                    title="+ Add UPI Autoload"
+                    description="UPI Autoload loads tables and variables in UPI payload into standard transformer registry"
+                    onClick={() =>
+                      onAddInput("autoload", new Autoload())
+                    }
+                  />
+                </EuiFlexItem>
+            )}
             <EuiFlexItem>
               <AddButton
                 title="+ Add Feast Input"
@@ -185,17 +196,6 @@ export const InputPanel = ({ inputs = [], onChangeHandler, protocol, errors = {}
                 }
               />
               </EuiFlexItem>
-              { protocol === PROTOCOL.UPI_V1 && (
-                <EuiFlexItem>
-                  <AddButton
-                    title="+ Add Autoload"
-                    description="Autoload configuration register tables and variables to standard transformer registry"
-                    onClick={() =>
-                      onAddInput("autoload", new Autoload())
-                    }
-                  />
-                </EuiFlexItem>
-              )}
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/ui/src/pages/version/components/forms/components/transformer/InputPanel.js
+++ b/ui/src/pages/version/components/forms/components/transformer/InputPanel.js
@@ -22,7 +22,7 @@ import {
   TablesInput
 } from "../../../../../../services/transformer/TransformerConfig";
 
-import {PROTOCOL} from "../../../../../../services/version_endpoint/VersionEndpoint"
+import {PROTOCOL} from "../../../../../../services/version_endpoint/VersionEndpoint";
 
 export const InputPanel = ({ inputs = [], onChangeHandler, protocol, errors = {} }) => {
   const { onChange } = useOnChangeHandler(onChangeHandler);

--- a/ui/src/pages/version/components/forms/components/transformer/OutputPanel.js
+++ b/ui/src/pages/version/components/forms/components/transformer/OutputPanel.js
@@ -39,7 +39,7 @@ export const OutputPanel = ({ outputs = [], protocol, pipelineStage, onChangeHan
             <EuiDraggable
                 key={`output-${idx}`}
                 index={idx}
-                draggableId={`${idx}`}
+                draggableId={`output-${idx}`}
                 customDragHandle={true}
                 disableInteractiveElementBlocking>
               {

--- a/ui/src/pages/version/components/forms/components/transformer/OutputPanel.js
+++ b/ui/src/pages/version/components/forms/components/transformer/OutputPanel.js
@@ -1,271 +1,100 @@
-import React, { useCallback, useEffect, useState } from "react";
 import {
   EuiDragDropContext,
-  euiDragDropReorder,
   EuiDraggable,
   EuiDroppable,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer
 } from "@elastic/eui";
-import { get, useOnChangeHandler } from "@gojek/mlp-ui";
 import { Panel } from "../Panel";
-import { AddButton } from "./components/AddButton";
-import { JsonOutputFieldCard } from "./components/table_outputs/JsonOutputFieldCard";
-import { BaseJsonOutputCard } from "./components/table_outputs/BaseJsonOutputCard";
 import {
-  BaseJson,
-  JsonOutput
-} from "../../../../../../services/transformer/TransformerConfig";
+  JsonOutputCard
+} from "./components/table_outputs/JsonOutputCard";
+import {
+  UpiPreprocessOutputCard
+} from "./components/table_outputs/UpiPreprocessOutputCard";
+import {
+  UpiPostprocessOutputCard
+} from "./components/table_outputs/UpiPostprocessOutputCard";
+import { Output } from "../../../../../../services/transformer/TransformerConfig";
+import { AddButton } from "./components/AddButton";
 
-const expandFields = flattenField => {
-  let fields = [];
 
-  flattenField.forEach(f => {
-    if (f.fieldName === undefined) {
-      return;
-    }
-
-    const nameSegments = splitName(f.fieldName);
-    let newField = {
-      ...f,
-      fieldName: nameSegments[nameSegments.length - 1]
-    };
-
-    fields = generateOutputFields(fields, nameSegments, newField);
-  });
-
-  return fields;
-};
-
-const splitName = name => {
-  // https://stackoverflow.com/questions/171480/regex-grabbing-values-between-quotation-marks
-  return (
-    name
-      // eslint-disable-next-line no-useless-escape
-      .split(/\.(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/g)
-      // eslint-disable-next-line no-useless-escape
-      .map(n => n.replace(/\"/g, ""))
-  );
-};
-
-const generateOutputFields = (fields, nameSegment, fieldValue) => {
-  if (nameSegment.length <= 1) {
-    fields.push({ ...fieldValue, fields: [] });
-    return fields;
-  }
-
-  let field = searchField(fields, nameSegment[0]);
-  if (field === undefined) {
-    field = {
-      fieldName: nameSegment[0],
-      fields: []
-    };
-    fields.push(field);
-  }
-
-  generateOutputFields(field.fields, nameSegment.slice(1), fieldValue);
-  return fields;
-};
-
-const searchField = (fields, fieldName) => {
-  return fields && fields.find(f => f.fieldName === fieldName);
-};
-
-const flattenField = fields => {
-  let all = [];
-  fields.forEach(f => {
-    const flattenedFields = flatten(f, [f.fieldName]);
-    all = all.concat(flattenedFields);
-  });
-  return all;
-};
-
-const flatten = (field, path) => {
-  if (field.fields === undefined || field.fields.length === 0) {
-    return [
-      {
-        ...field,
-        fieldName: mergePath(path)
-      }
-    ];
-  }
-
-  let fields = [];
-  field.fields.forEach(f => {
-    path.push(f.fieldName);
-    fields = fields.concat(flatten(f, path));
-    path.pop();
-  });
-  return fields;
-};
-
-const mergePath = path => {
-  if (path.length === 1) {
-    return path[0];
-  }
-
-  return '"' + path.join('"."') + '"';
-};
-
-export const OutputPanel = ({ outputs = [], onChangeHandler, errors = {} }) => {
-  const { onChange } = useOnChangeHandler(onChangeHandler);
-
-  const [flattenedFields, setFlattenedFields] = useState([]);
-  useEffect(
-    () => {
-      const newFlattenedFields = flattenField(
-        outputs.length > 0
-          ? Array.isArray(
-              outputs[outputs.length - 1].jsonOutput.jsonTemplate.fields
-            )
-            ? outputs[outputs.length - 1].jsonOutput.jsonTemplate.fields
-            : []
-          : []
-      );
-      if (
-        JSON.stringify(flattenedFields) !== JSON.stringify(newFlattenedFields)
-      ) {
-        setFlattenedFields(newFlattenedFields);
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [outputs]
-  );
-
-  useEffect(
-    () => {
-      if (flattenedFields.length > 0) {
-        let fields = expandFields(flattenedFields);
-        onChange(`0.jsonOutput.jsonTemplate.fields`)(fields);
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [flattenedFields]
-  );
-
-  const onFieldChange = (idx, fieldObj) => {
-    flattenedFields[idx] = fieldObj;
-    setFlattenedFields([...flattenedFields]);
+export const OutputPanel = ({ outputs = [], protocol, pipelineStage, onChangeHandler, errors = {} }) => {
+  const onAddOutput = () => {
+    let output = new Output(protocol, pipelineStage)
+    onChangeHandler([...outputs,  output]);
   };
-
-  const onAddBaseJson = useCallback(
-    (field, input) => {
-      onChangeHandler([{ [field]: input }]);
-    },
-    [onChangeHandler]
-  );
-
-  const onDeleteJsonOutputField = idx => () => {
-    flattenedFields.splice(idx, 1);
-    setFlattenedFields([...flattenedFields]);
-  };
-
-  const onDragEnd = ({ source, destination }) => {
-    if (source && destination) {
-      const items = euiDragDropReorder(
-        flattenedFields,
-        source.index,
-        destination.index
-      );
-      setFlattenedFields(items);
-    }
-  };
-
+  const onDeleteOutputIdx = (idx) => {
+    outputs.splice(idx, 1);
+    onChangeHandler([...outputs])
+  }
   return (
     <Panel title="Output" contentWidth="92%">
       <EuiSpacer size="s" />
-
-      {outputs.findIndex(
-        output =>
-          output.jsonOutput &&
-          output.jsonOutput.jsonTemplate &&
-          output.jsonOutput.jsonTemplate.baseJson
-      ) !== -1 && (
-        <EuiFlexGroup direction="column" gutterSize="s">
-          <EuiFlexItem>
-            <BaseJsonOutputCard
-              baseJson={outputs[0].jsonOutput.jsonTemplate.baseJson}
-              onChangeHandler={onChange(`0.jsonOutput.jsonTemplate.baseJson`)}
-              errors={get(errors, `0.jsonOutput.jsonTemplate.baseJson`)}
-              onDelete={() => {
-                onChange(`0.jsonOutput.jsonTemplate.baseJson`)(undefined);
-              }}
-            />
-            <EuiSpacer size="s" />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      )}
-
-      <EuiDragDropContext onDragEnd={onDragEnd}>
-        <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiDragDropContext>
           <EuiDroppable droppableId="OUTPUTS_DROPPABLE_AREA" spacing="m">
-            {flattenedFields.map((field, fieldIdx) => (
-              <EuiDraggable
-                key={`fields-${fieldIdx}`}
-                index={fieldIdx}
-                draggableId={`fields-${fieldIdx}`}
+          { outputs.map((output, idx) => (
+            <EuiDraggable
+                key={`output-${idx}`}
+                index={idx}
+                draggableId={`${idx}`}
                 customDragHandle={true}
                 disableInteractiveElementBlocking>
-                {provided => (
-                  <EuiFlexItem key={`fields-${fieldIdx}`}>
-                    <JsonOutputFieldCard
-                      index={fieldIdx}
-                      field={field}
-                      onChange={onFieldChange}
-                      onDelete={onDeleteJsonOutputField(fieldIdx)}
-                      dragHandleProps={provided.dragHandleProps}
-                    />
-                    <EuiSpacer size="s" />
-                  </EuiFlexItem>
-                )}
-              </EuiDraggable>
-            ))}
-          </EuiDroppable>
-
-          <EuiSpacer size="s" />
-
-          <EuiFlexGroup direction="row" gutterSize="s">
-            {outputs.findIndex(
-              output =>
-                output.jsonOutput &&
-                output.jsonOutput.jsonTemplate &&
-                output.jsonOutput.jsonTemplate.baseJson
-            ) === -1 && (
-              <EuiFlexItem>
-                <AddButton
-                  title="+ Add Base JSON"
-                  description="Copy the structure and value from another JSON object or array using JSONPath."
-                  onClick={() => {
-                    var jsonOutput = new JsonOutput();
-                    if (outputs.length > 0) {
-                      jsonOutput = outputs[0].jsonOutput;
+              {
+                provided => (
+                  <EuiFlexItem>
+                    {output.jsonOutput && (
+                        <JsonOutputCard 
+                          jsonOutput={output.jsonOutput}
+                          onChangeHandler={onChangeHandler}
+                          errors={errors}
+                          onDelete={() => onDeleteOutputIdx(idx)}
+                          dragHandleProps={provided.dragHandleProps}
+                        />
+                      )
                     }
-                    jsonOutput = {
-                      ...jsonOutput,
-                      jsonTemplate: {
-                        ...jsonOutput.jsonTemplate,
-                        baseJson: new BaseJson()
-                      }
-                    };
-                    onAddBaseJson("jsonOutput", jsonOutput);
-                  }}
-                />
-              </EuiFlexItem>
-            )}
-
-            <EuiFlexItem>
-              <AddButton
-                title="+ Add Field"
-                description="Create a field from JSONPath, table, or expression."
-                onClick={() => {
-                  setFlattenedFields([...flattenedFields, {}]);
-                }}
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexGroup>
-      </EuiDragDropContext>
+                    {
+                      output.upiPreprocessOutput && (
+                        <UpiPreprocessOutputCard
+                          output={output.upiPreprocessOutput}
+                          onDelete={() => onDeleteOutputIdx(idx)}
+                          onChangeHandler={onChangeHandler}
+                          errors={errors}
+                          dragHandleProps={provided.dragHandleProps}
+                        />
+                      )
+                    }
+                    {
+                      output.upiPostprocessOutput && (
+                        <UpiPostprocessOutputCard
+                          output={output.upiPostprocessOutput}
+                          onDelete={() => onDeleteOutputIdx(idx)}
+                          onChangeHandler={onChangeHandler}
+                          errors={errors}
+                          dragHandleProps={provided.dragHandleProps}
+                        />
+                      )
+                    }
+                  </EuiFlexItem>
+                )
+              }
+            </EuiDraggable>
+          ))
+          }  
+          </EuiDroppable>
+        </EuiDragDropContext>
+        {outputs.length === 0 && (
+          <EuiFlexItem>
+            <AddButton
+              title="+ Add Output"
+              description="Add Output operation"
+              titleSize="xs"
+              onClick={() => onAddOutput()} />
+          </EuiFlexItem>)
+        }
+      </EuiFlexGroup>
     </Panel>
   );
 };

--- a/ui/src/pages/version/components/forms/components/transformer/PipelineStage.js
+++ b/ui/src/pages/version/components/forms/components/transformer/PipelineStage.js
@@ -26,6 +26,12 @@ export const PipelineStage = ({ stage }) => {
     onChangeHandler
   } = useContext(FormContext);
 
+  const {
+    data: versionEndpoint
+  } = useContext(FormContext)
+
+  const protocol = versionEndpoint.protocol
+
   const { onChange } = useOnChangeHandler(onChangeHandler);
   const { errors } = useContext(FormValidationContext);
 
@@ -38,6 +44,7 @@ export const PipelineStage = ({ stage }) => {
               <FeastProjectsContextProvider>
                 <InputPanel
                   inputs={inputs}
+                  protocol={protocol}
                   onChangeHandler={onChange(
                     `transformer.config.transformerConfig.${stage}.inputs`
                   )}
@@ -69,6 +76,8 @@ export const PipelineStage = ({ stage }) => {
             <Element name={"output-" + stage}>
               <OutputPanel
                 outputs={outputs}
+                protocol={protocol}
+                pipelineStage={stage}
                 onChangeHandler={onChange(
                   `transformer.config.transformerConfig.${stage}.outputs`
                 )}

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_inputs/AutoloadCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_inputs/AutoloadCard.js
@@ -45,7 +45,7 @@ export const AutoloadCard = ({
               title="Table names"
               description={
                 <p>
-                  List of table name that must be loaded from request/response and can be used for other operations
+                  List of table names that will be loaded from request/response and can be used for other operations in standard transformer
                 </p>
               }
               errors={get(errors, "tableNames")}
@@ -58,7 +58,7 @@ export const AutoloadCard = ({
               title="Variable names"
               description={
                 <p>
-                  List of variable name that must be loaded from request/response and can be used for other operations
+                  List of variable names that will be loaded from request/response and can be used for other operations in standard transformer
                 </p>
               }
               errors={get(errors, "variableNames")}

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_inputs/AutoloadCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_inputs/AutoloadCard.js
@@ -29,10 +29,10 @@ export const AutoloadCard = ({
         <EuiSpacer size="s" />
         <EuiFlexGroup direction="column" gutterSize="m">
           <EuiFlexItem>
-            <EuiToolTip content="Autoload will load tables or variables from request/model response">
+            <EuiToolTip content="UPI Autoload loads tables or variables from UPI payload into standard transformer registry">
               <span>
               <EuiText size="s">
-                <h4>Autoload</h4>
+                <h4>UPI Autoload</h4>
               </EuiText>
                 
               </span>

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_inputs/AutoloadCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_inputs/AutoloadCard.js
@@ -1,0 +1,72 @@
+import {
+  EuiFlexGroup,
+  EuiPanel,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiToolTip,
+  EuiText
+  } from "@elastic/eui";
+import { get } from "@gojek/mlp-ui";
+import { useOnChangeHandler } from "@gojek/mlp-ui";
+import { ColumnsComboBox} from "../table_operations/ColumnsComboBox"
+import { DraggableHeader } from "../../../DraggableHeader";
+  
+export const AutoloadCard = ({ 
+    autoload={}, 
+    onDelete, 
+    onChangeHandler, 
+    errors = {}, 
+    ...props }) => {
+    
+    const { onChange } = useOnChangeHandler(onChangeHandler);
+    return (
+      <EuiPanel>
+        <DraggableHeader
+          onDelete={onDelete}
+          dragHandleProps={props.dragHandleProps}
+        />
+  
+        <EuiSpacer size="s" />
+        <EuiFlexGroup direction="column" gutterSize="m">
+          <EuiFlexItem>
+            <EuiToolTip content="Autoload will load tables or variables from request/model response">
+              <span>
+              <EuiText size="s">
+                <h4>Autoload</h4>
+              </EuiText>
+                
+              </span>
+            </EuiToolTip>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <ColumnsComboBox
+              columns={autoload.tableNames || []}
+              onChange={onChange("tableNames")}
+              title="Table names"
+              description={
+                <p>
+                  List of table name that must be loaded from request/response and can be used for other operations
+                </p>
+              }
+              errors={get(errors, "tableNames")}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <ColumnsComboBox
+              columns={autoload.variableNames || []}
+              onChange={onChange("variableNames")}
+              title="Variable names"
+              description={
+                <p>
+                  List of variable name that must be loaded from request/response and can be used for other operations
+                </p>
+              }
+              errors={get(errors, "variableNames")}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        
+      </EuiPanel>
+    )
+  }
+  

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/JsonOutputCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/JsonOutputCard.js
@@ -1,0 +1,286 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  EuiDragDropContext,
+  euiDragDropReorder,
+  EuiDraggable,
+  EuiDroppable,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiToolTip,
+  EuiText
+} from "@elastic/eui";
+import { get, useOnChangeHandler } from "@gojek/mlp-ui";
+import { AddButton } from "../../components/AddButton";
+import { JsonOutputFieldCard } from "./JsonOutputFieldCard";
+import { BaseJsonOutputCard } from "./BaseJsonOutputCard";
+import {
+  BaseJson,
+} from "../../../../../../../../services/transformer/TransformerConfig";
+import { DraggableHeader } from "../../../../components/DraggableHeader";
+
+
+const expandFields = flattenField => {
+    let fields = [];
+  
+    flattenField.forEach(f => {
+      if (f.fieldName === undefined) {
+        return;
+      }
+  
+      const nameSegments = splitName(f.fieldName);
+      let newField = {
+        ...f,
+        fieldName: nameSegments[nameSegments.length - 1]
+      };
+  
+      fields = generateOutputFields(fields, nameSegments, newField);
+    });
+  
+    return fields;
+};
+  
+const splitName = name => {
+    // https://stackoverflow.com/questions/171480/regex-grabbing-values-between-quotation-marks
+    return (
+      name
+        // eslint-disable-next-line no-useless-escape
+        .split(/\.(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/g)
+        // eslint-disable-next-line no-useless-escape
+        .map(n => n.replace(/\"/g, ""))
+    );
+  };
+  
+  const generateOutputFields = (fields, nameSegment, fieldValue) => {
+    if (nameSegment.length <= 1) {
+      fields.push({ ...fieldValue, fields: [] });
+      return fields;
+    }
+  
+    let field = searchField(fields, nameSegment[0]);
+    if (field === undefined) {
+      field = {
+        fieldName: nameSegment[0],
+        fields: []
+      };
+      fields.push(field);
+    }
+  
+    generateOutputFields(field.fields, nameSegment.slice(1), fieldValue);
+    return fields;
+};
+  
+const searchField = (fields, fieldName) => {
+    return fields && fields.find(f => f.fieldName === fieldName);
+};
+  
+const flattenField = fields => {
+    let all = [];
+    fields.forEach(f => {
+      const flattenedFields = flatten(f, [f.fieldName]);
+      all = all.concat(flattenedFields);
+    });
+    return all;
+};
+  
+const flatten = (field, path) => {
+    if (field.fields === undefined || field.fields.length === 0) {
+      return [
+        {
+          ...field,
+          fieldName: mergePath(path)
+        }
+      ];
+    }
+  
+    let fields = [];
+    field.fields.forEach(f => {
+      path.push(f.fieldName);
+      fields = fields.concat(flatten(f, path));
+      path.pop();
+    });
+    return fields;
+};
+  
+const mergePath = path => {
+    if (path.length === 1) {
+      return path[0];
+    }
+  
+    return '"' + path.join('"."') + '"';
+};
+
+export const JsonOutputCard = ({ 
+  jsonOutput, 
+  onDelete,
+  onChangeHandler, 
+  errors = {},
+  ...props
+}) => {
+    const { onChange } = useOnChangeHandler(onChangeHandler);
+  
+    const [flattenedFields, setFlattenedFields] = useState([]);
+    useEffect(
+      () => {
+        const fields = Array.isArray(
+            jsonOutput.jsonTemplate.fields
+        ) ? jsonOutput.jsonTemplate.fields
+        : []
+
+        const newFlattenedFields = flattenField(fields);
+        if (
+          JSON.stringify(flattenedFields) !== JSON.stringify(newFlattenedFields)
+        ) {
+          setFlattenedFields(newFlattenedFields);
+        }
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [jsonOutput]
+    );
+  
+    useEffect(
+      () => {
+        if (flattenedFields.length > 0) {
+          let fields = expandFields(flattenedFields);
+          onChange(`0.jsonOutput.jsonTemplate.fields`)(fields);
+        }
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [flattenedFields]
+    );
+  
+    const onFieldChange = (idx, fieldObj) => {
+      flattenedFields[idx] = fieldObj;
+      setFlattenedFields([...flattenedFields]);
+    };
+  
+    const onAddBaseJson = useCallback(
+      (field, input) => {
+        onChangeHandler([{ [field]: input }]);
+      },
+      [onChangeHandler]
+    );
+  
+    const onDeleteJsonOutputField = idx => () => {
+      flattenedFields.splice(idx, 1);
+      setFlattenedFields([...flattenedFields]);
+    };
+  
+    const onDragEnd = ({ source, destination }) => {
+      if (source && destination) {
+        const items = euiDragDropReorder(
+          flattenedFields,
+          source.index,
+          destination.index
+        );
+        setFlattenedFields(items);
+      }
+    };
+  
+    return (
+    <EuiPanel>
+        
+        <DraggableHeader
+          onDelete={onDelete}
+          dragHandleProps={props.dragHandleProps}
+        />
+        <EuiSpacer size="s" />
+        <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexItem>
+            <EuiToolTip content="JSON Output will create output in JSON format">
+              <span>
+              <EuiText size="s">
+                <h4>JSON Output</h4>
+              </EuiText>
+                
+              </span>
+            </EuiToolTip>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        {
+            jsonOutput &&
+            jsonOutput.jsonTemplate &&
+            jsonOutput.jsonTemplate.baseJson && (
+            <EuiFlexGroup direction="column" gutterSize="s">
+              <EuiFlexItem>
+                <BaseJsonOutputCard
+                  baseJson={jsonOutput.jsonTemplate.baseJson}
+                  onChangeHandler={onChange(`0.jsonOutput.jsonTemplate.baseJson`)}
+                  errors={get(errors, `0.jsonOutput.jsonTemplate.baseJson`)}
+                  onDelete={() => {
+                    onChange(`0.jsonOutput.jsonTemplate.baseJson`)(undefined);
+                  }}
+                />
+                <EuiSpacer size="s" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+        )}
+  
+        <EuiDragDropContext onDragEnd={onDragEnd}>
+          <EuiFlexGroup direction="column" gutterSize="s">
+            <EuiDroppable droppableId="OUTPUTS_DROPPABLE_AREA" spacing="m">
+              {flattenedFields.map((field, fieldIdx) => (
+                <EuiDraggable
+                  key={`fields-${fieldIdx}`}
+                  index={fieldIdx}
+                  draggableId={`fields-${fieldIdx}`}
+                  customDragHandle={true}
+                  disableInteractiveElementBlocking>
+                  {provided => (
+                    <EuiFlexItem key={`fields-${fieldIdx}`}>
+                      <JsonOutputFieldCard
+                        index={fieldIdx}
+                        field={field}
+                        onChange={onFieldChange}
+                        onDelete={onDeleteJsonOutputField(fieldIdx)}
+                        dragHandleProps={provided.dragHandleProps}
+                      />
+                      <EuiSpacer size="s" />
+                    </EuiFlexItem>
+                  )}
+                </EuiDraggable>
+              ))}
+            </EuiDroppable>
+  
+            <EuiSpacer size="s" />
+  
+            <EuiFlexGroup direction="row" gutterSize="s">
+              { jsonOutput &&
+                jsonOutput.jsonTemplate &&
+                !jsonOutput.jsonTemplate.baseJson
+               && (
+                <EuiFlexItem>
+                  <AddButton
+                    title="+ Add Base JSON"
+                    description="Copy the structure and value from another JSON object or array using JSONPath."
+                    onClick={() => {
+                      var output = {
+                        ...jsonOutput,
+                        jsonTemplate: {
+                          ...jsonOutput.jsonTemplate,
+                          baseJson: new BaseJson()
+                        }
+                      };
+                      onAddBaseJson("jsonOutput", output);
+                    }}
+                  />
+                </EuiFlexItem>
+              )}
+  
+              <EuiFlexItem>
+                <AddButton
+                  title="+ Add Field"
+                  description="Create a field from JSONPath, table, or expression."
+                  onClick={() => {
+                    setFlattenedFields([...flattenedFields, {}]);
+                  }}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexGroup>
+        </EuiDragDropContext>
+      </EuiPanel>
+    );
+};
+  

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPostprocessOutputCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPostprocessOutputCard.js
@@ -38,7 +38,7 @@ export const UpiPostprocessOutputCard = ({ output, onDelete, onChangeHandler, er
         <EuiFlexItem>
           <EuiFormRow
             label={
-              <EuiToolTip content="Prediction Result Table Name corresponding to the prediction rows provided in the request">
+              <EuiToolTip content="Table name that will be used to populate prediction_result_table in the response to client">
                 <span>
                 Prediction Result Table Name <EuiIcon type="questionInCircle" color="subdued" />
                 </span>

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPostprocessOutputCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPostprocessOutputCard.js
@@ -54,7 +54,7 @@ export const UpiPostprocessOutputCard = ({ output, onDelete, onChangeHandler, er
               onChange={e =>
                 onChange("0.upiPostprocessOutput.predictionResultTableName")(e.target.value)
               }
-              name="prediction-table-name"
+              name="prediction-result-table-name"
               isInvalid={!!errors.predictionResultTableName}
               fullWidth
             />

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPostprocessOutputCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPostprocessOutputCard.js
@@ -6,7 +6,8 @@ import {
   EuiFieldText,
   EuiToolTip,
   EuiText,
-  EuiSpacer
+  EuiSpacer,
+  EuiIcon
 
 } from "@elastic/eui";
 import {
@@ -36,7 +37,13 @@ export const UpiPostprocessOutputCard = ({ output, onDelete, onChangeHandler, er
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiFormRow
-            label="Prediction Result Table Name"
+            label={
+              <EuiToolTip content="Prediction Result Table Name corresponding to the prediction rows provided in the request">
+                <span>
+                Prediction Result Table Name <EuiIcon type="questionInCircle" color="subdued" />
+                </span>
+              </EuiToolTip>
+            }
             isInvalid={!!errors.predictionResultTableName}
             error={errors.predictionResultTableName}
             display="columnCompressed"

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPostprocessOutputCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPostprocessOutputCard.js
@@ -1,0 +1,60 @@
+import {
+  EuiFlexGroup,
+  EuiPanel,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiFieldText,
+  EuiToolTip,
+  EuiText,
+  EuiSpacer
+
+} from "@elastic/eui";
+import {
+  useOnChangeHandler
+} from "@gojek/mlp-ui";
+import { DraggableHeader } from "../../../DraggableHeader";
+
+export const UpiPostprocessOutputCard = ({ output, onDelete, onChangeHandler, errors = {}, ...props }) => {
+  const { onChange } = useOnChangeHandler(onChangeHandler);
+  return (
+    <EuiPanel>
+      <DraggableHeader
+        onDelete={onDelete}
+        dragHandleProps={props.dragHandleProps}
+      />
+      <EuiSpacer size="s"/>
+      <EuiFlexGroup direction="column" gutterSize="m">
+        <EuiFlexItem>
+          <EuiToolTip content="UPI Postprocess Output will create output in UPI PredictionValueResponse type">
+            <span>
+            <EuiText size="s">
+              <h4>UPI Postprocess Output</h4>
+            </EuiText>
+              
+            </span>
+          </EuiToolTip>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFormRow
+            label="Prediction Result Table Name"
+            isInvalid={!!errors.predictionResultTableName}
+            error={errors.predictionResultTableName}
+            display="columnCompressed"
+            fullWidth>
+            <EuiFieldText
+              placeholder="Prediction Result Table Name"
+              value={output.predictionResultTableName || ""}
+              onChange={e =>
+                onChange("0.upiPostprocessOutput.predictionResultTableName")(e.target.value)
+              }
+              name="prediction-table-name"
+              isInvalid={!!errors.predictionResultTableName}
+              fullWidth
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      
+    </EuiPanel>
+  )
+}

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPreprocessOutputCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPreprocessOutputCard.js
@@ -1,0 +1,76 @@
+import {
+  EuiFlexGroup,
+  EuiPanel,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiFieldText,
+  EuiToolTip,
+  EuiText,
+  EuiSpacer
+
+} from "@elastic/eui";
+import {
+  get, 
+  useOnChangeHandler
+} from "@gojek/mlp-ui";
+import {ColumnsComboBox} from "../table_operations/ColumnsComboBox"
+import { DraggableHeader } from "../../../DraggableHeader";
+
+
+export const UpiPreprocessOutputCard = ({ output, onDelete, onChangeHandler, errors = {}, ...props }) => {
+  const { onChange } = useOnChangeHandler(onChangeHandler);
+  return (
+    <EuiPanel>
+      <DraggableHeader
+        onDelete={onDelete}
+        dragHandleProps={props.dragHandleProps}
+      />
+      <EuiSpacer size="s" />
+      <EuiFlexGroup direction="column" gutterSize="m">
+        <EuiFlexItem>
+          <EuiToolTip content="UPI Preprocess Output will create output in UPI PredictionValueRequest type">
+            <span>
+            <EuiText size="s">
+              <h4>UPI Preprocess Output</h4>
+            </EuiText>
+              
+            </span>
+          </EuiToolTip>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFormRow
+            label="Prediction Table Name"
+            isInvalid={!!errors.predictionTableName}
+            error={errors.predictionTableName}
+            display="columnCompressed"
+            fullWidth>
+            <EuiFieldText
+              placeholder="Prediction Table Name"
+              value={output.predictionTableName || ""}
+              onChange={e =>
+                onChange("0.upiPreprocessOutput.predictionTableName")(e.target.value)
+              }
+              name="prediction-table-name"
+              isInvalid={!!errors.predictionTableName}
+              fullWidth
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <ColumnsComboBox
+            columns={output.transformerInputTableNames || []}
+            onChange={onChange("0.upiPreprocessOutput.transformerInputTableNames")}
+            title="Transformer input table names"
+            description={
+              <p>
+                List of transformer input table name
+              </p>
+            }
+            errors={get(errors, "transformerInputTableNames")}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      
+    </EuiPanel>
+  )
+}

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPreprocessOutputCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPreprocessOutputCard.js
@@ -41,7 +41,7 @@ export const UpiPreprocessOutputCard = ({ output, onDelete, onChangeHandler, err
         <EuiFlexItem>
           <EuiFormRow
             label={
-              <EuiToolTip content="Prediction Table Name contains instances to be predicted. This should contain all preprocessed feature that model use to perform prediction">
+              <EuiToolTip content="Table name that will be used to populate prediction_table field in the request to model">
                 <span>
                 Prediction Table Name <EuiIcon type="questionInCircle" color="subdued" />
                 </span>
@@ -68,7 +68,7 @@ export const UpiPreprocessOutputCard = ({ output, onDelete, onChangeHandler, err
             columns={output.transformerInputTableNames || []}
             onChange={onChange("0.upiPreprocessOutput.transformerInputTableNames")}
             title={
-              <EuiToolTip content="Transformer input table names contains tables that can be used to enrich prediction_table using standard transformer">
+              <EuiToolTip content="List of table names that will be used to populate transformer_inputs field in the request to model">
                 <span>
                 Transformer input table names <EuiIcon type="questionInCircle" color="subdued" />
                 </span>

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPreprocessOutputCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPreprocessOutputCard.js
@@ -6,7 +6,8 @@ import {
   EuiFieldText,
   EuiToolTip,
   EuiText,
-  EuiSpacer
+  EuiSpacer,
+  EuiIcon
 
 } from "@elastic/eui";
 import {
@@ -39,7 +40,13 @@ export const UpiPreprocessOutputCard = ({ output, onDelete, onChangeHandler, err
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiFormRow
-            label="Prediction Table Name"
+            label={
+              <EuiToolTip content="Prediction Table Name contains instances to be predicted. This should contain all preprocessed feature that model use to perform prediction">
+                <span>
+                Prediction Table Name <EuiIcon type="questionInCircle" color="subdued" />
+                </span>
+              </EuiToolTip>
+            }
             isInvalid={!!errors.predictionTableName}
             error={errors.predictionTableName}
             display="columnCompressed"

--- a/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPreprocessOutputCard.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/table_outputs/UpiPreprocessOutputCard.js
@@ -67,7 +67,13 @@ export const UpiPreprocessOutputCard = ({ output, onDelete, onChangeHandler, err
           <ColumnsComboBox
             columns={output.transformerInputTableNames || []}
             onChange={onChange("0.upiPreprocessOutput.transformerInputTableNames")}
-            title="Transformer input table names"
+            title={
+              <EuiToolTip content="Transformer input table names contains tables that can be used to enrich prediction_table using standard transformer">
+                <span>
+                Transformer input table names <EuiIcon type="questionInCircle" color="subdued" />
+                </span>
+              </EuiToolTip>
+            }
             description={
               <p>
                 List of transformer input table name

--- a/ui/src/pages/version/components/forms/steps/PipelineStage.js
+++ b/ui/src/pages/version/components/forms/steps/PipelineStage.js
@@ -24,6 +24,7 @@ export const PipelineStage = ({ stage }) => {
     },
     onChangeHandler
   } = useContext(FormContext);
+
   const { onChange } = useOnChangeHandler(onChangeHandler);
   const { errors } = useContext(FormValidationContext);
 
@@ -67,6 +68,8 @@ export const PipelineStage = ({ stage }) => {
             <div id={"output-" + stage}>
               <OutputPanel
                 outputs={outputs}
+                protocol={protocol}
+                pipelineStage={stage}
                 onChangeHandler={onChange(
                   `transformer.config.transformerConfig.${stage}.outputs`
                 )}

--- a/ui/src/services/transformer/TransformerConfig.js
+++ b/ui/src/services/transformer/TransformerConfig.js
@@ -20,6 +20,7 @@ import {
   feastInputSchema,
   pipelineSchema
 } from "../../pages/version/components/forms/validation/schema";
+import { PROTOCOL } from "../version_endpoint/VersionEndpoint"
 
 const objectAssignDeep = require(`object-assign-deep`);
 
@@ -44,6 +45,11 @@ export const getFeastSource = feastConfig => {
 
 export const STANDARD_TRANSFORMER_CONFIG_ENV_NAME =
   "STANDARD_TRANSFORMER_CONFIG";
+
+export const PIPELINE_STEP = {
+  Preprocess: "preprocess",
+  Postprocess: "postprocess"
+}
 
 export class Config {
   constructor(transformerConfig) {
@@ -171,7 +177,6 @@ export class Pipeline {
     this.inputs = [];
     this.transformations = [];
     this.outputs = [];
-
     this.toJSON = this.toJSON.bind(this);
   }
 
@@ -482,6 +487,13 @@ export class TablesInput {
   }
 }
 
+export class Autoload {
+  constructor() {
+    this.tableNames = []
+    this.variableNames = []
+  }
+}
+
 export class Transformations {
   constructor() {
     this.tableTransformation = new TableTransformation();
@@ -508,8 +520,29 @@ export class TableJoin {
 }
 
 export class Output {
+  constructor(protocol, pipelineStage) {
+    if (protocol === PROTOCOL.UPI_V1) {
+      if (pipelineStage === PIPELINE_STEP.Preprocess) {
+        this.upiPreprocessOutput = new UPIPreprocessOutput()
+      } else {
+        this.upiPostprocessOutput = new UPIPostprocessOutput()
+      }
+    } else {
+      this.jsonOutput = new JsonOutput();
+    }
+  }
+}
+
+export class UPIPreprocessOutput {
   constructor() {
-    this.jsonOutput = new JsonOutput();
+    this.predictionTableName = ""
+    this.transformerInputTableNames = []
+  }
+}
+
+export class UPIPostprocessOutput {
+  constructor() {
+    this.predictionResultTableName = ""
   }
 }
 

--- a/ui/src/services/version_endpoint/VersionEndpoint.js
+++ b/ui/src/services/version_endpoint/VersionEndpoint.js
@@ -3,6 +3,11 @@ import { Transformer } from "../transformer/Transformer";
 
 const objectAssignDeep = require(`object-assign-deep`);
 
+export const PROTOCOL = {
+  HTTP_JSON: "HTTP_JSON",
+  UPI_V1: "UPI_V1"
+}
+
 export class VersionEndpoint {
   constructor() {
     this.id = undefined;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
In previous [PR](https://github.com/gojek/merlin/pull/286) we introduce new operation to support UPI in standard transformer, this PR adding the UI components for those operations.

This PR add 3 components:
* AutoloadCard -> Component to render Autoload spec
* UpiPreprocessOutputCard -> Component to render UPI preprocess output spec
* UpiPostprocessOutputCard -> Component to render UPI postprocess output spec


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

https://user-images.githubusercontent.com/2369255/193496926-98cc2ec2-34f0-40ed-b18a-017cc246b97d.mov



```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
