### PR TITLE
Add livenessprobe from UPI protocol

### DIFF
--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gojek/merlin/models"
 	"github.com/gojek/merlin/pkg/autoscaling"
 	"github.com/gojek/merlin/pkg/deployment"
+	prt "github.com/gojek/merlin/pkg/protocol"
 	transformerpkg "github.com/gojek/merlin/pkg/transformer"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	kserveconstant "github.com/kserve/kserve/pkg/constants"
@@ -74,6 +75,8 @@ const (
 	defaultHTTPPort                  = 8080
 	defaultGRPCPort                  = 9000
 	defaultPredictorPort             = 80
+
+	grpcHealthProbeCommand = "grpc_health_probe"
 )
 
 var (
@@ -180,8 +183,7 @@ func createPredictorSpec(modelService *models.Service, config *config.Deployment
 	envVarsMap := envVars.ToMap()
 	if !strings.EqualFold(envVarsMap[envOldDisableLivenessProbe], "true") &&
 		!strings.EqualFold(envVarsMap[envDisableLivenessProbe], "true") {
-		isPyfunc := modelService.Type == models.ModelTypePyFunc
-		livenessProbeConfig = createLivenessProbeSpec(modelService.Protocol, isPyfunc, fmt.Sprintf("/v1/models/%s", modelService.Name))
+		livenessProbeConfig = createLivenessProbeSpec(modelService.Protocol)
 	}
 
 	containerPorts := createContainerPorts(modelService.Protocol)
@@ -326,7 +328,7 @@ func (t *InferenceServiceTemplater) createTransformerSpec(modelService *models.S
 	envVarsMap := envVars.ToMap()
 	if !strings.EqualFold(envVarsMap[envOldDisableLivenessProbe], "true") &&
 		!strings.EqualFold(envVarsMap[envDisableLivenessProbe], "true") {
-		livenessProbeConfig = createLivenessProbeSpec(modelService.Protocol, false, "/")
+		livenessProbeConfig = createLivenessProbeSpec(modelService.Protocol)
 	}
 
 	containerPorts := createContainerPorts(modelService.Protocol)
@@ -408,11 +410,7 @@ func (t *InferenceServiceTemplater) enrichStandardTransformerEnvVars(envVars mod
 	return envVars
 }
 
-func createLivenessProbeSpec(prt protocol.Protocol, isPyfunc bool, httpPath string) *corev1.Probe {
-	port := defaultHTTPPort
-	if prt == protocol.UpiV1 && !isPyfunc {
-		port = defaultGRPCPort
-	}
+func createHTTPGetLivenessProbe(httpPath string, port int) *corev1.Probe {
 	return &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -429,6 +427,28 @@ func createLivenessProbeSpec(prt protocol.Protocol, isPyfunc bool, httpPath stri
 		SuccessThreshold:    liveProbeSuccessThreshold,
 		FailureThreshold:    liveProbeFailureThreshold,
 	}
+}
+
+func createGRPCLivenessProbe(port int) *corev1.Probe {
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			Exec: &corev1.ExecAction{
+				Command: []string{grpcHealthProbeCommand, fmt.Sprintf("-addr=:%d", port)},
+			},
+		},
+		InitialDelaySeconds: liveProbeInitialDelaySec,
+		TimeoutSeconds:      liveProbeTimeoutSec,
+		PeriodSeconds:       liveProbePeriodSec,
+		SuccessThreshold:    liveProbeSuccessThreshold,
+		FailureThreshold:    liveProbeFailureThreshold,
+	}
+}
+
+func createLivenessProbeSpec(protocol prt.Protocol) *corev1.Probe {
+	if protocol == prt.UpiV1 {
+		return createGRPCLivenessProbe(defaultGRPCPort)
+	}
+	return createHTTPGetLivenessProbe("/", defaultHTTPPort)
 }
 
 func createPredictorHost(modelService *models.Service) string {

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -153,8 +153,8 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
-	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	tests := []struct {
 		name               string
@@ -1366,7 +1366,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 									Resources:     expDefaultModelResourceRequests,
 									Ports:         grpcContainerPorts,
 									Env:           createPyFuncDefaultEnvVarsWithProtocol(modelSvc, protocol.UpiV1).ToKubernetesEnvVars(),
-									LivenessProbe: probeConfigUPI,
+									LivenessProbe: probeConfig,
 								},
 							},
 						},
@@ -1569,12 +1569,12 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
-	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
-	transformerProbeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, false, "/")
+	transformerProbeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, false, "/")
 	tests := []struct {
 		name     string
 		modelSvc *models.Service
@@ -2085,10 +2085,10 @@ func TestCreateInferenceServiceSpecWithLogger(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, false, "/")
 
 	tests := []struct {
 		name     string
@@ -2549,10 +2549,10 @@ func TestPatchInferenceServiceSpec(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, false, "/")
 
 	one := 1
 	minReplica := 1
@@ -3215,7 +3215,7 @@ func TestCreateTransformerSpec(t *testing.T) {
 	memoryLimit.Add(memoryRequest)
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, false, "/")
 
 	modelSvc := &models.Service{
 		Name:         "model-1",

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -153,8 +153,8 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
-	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson)
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1)
 
 	tests := []struct {
 		name               string
@@ -1366,7 +1366,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 									Resources:     expDefaultModelResourceRequests,
 									Ports:         grpcContainerPorts,
 									Env:           createPyFuncDefaultEnvVarsWithProtocol(modelSvc, protocol.UpiV1).ToKubernetesEnvVars(),
-									LivenessProbe: probeConfig,
+									LivenessProbe: probeConfigUPI,
 								},
 							},
 						},
@@ -1569,12 +1569,12 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
-	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson)
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1)
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, false, "/")
-	transformerProbeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, false, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson)
+	transformerProbeConfigUPI := createLivenessProbeSpec(protocol.UpiV1)
 	tests := []struct {
 		name     string
 		modelSvc *models.Service
@@ -2085,10 +2085,10 @@ func TestCreateInferenceServiceSpecWithLogger(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson)
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, false, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson)
 
 	tests := []struct {
 		name     string
@@ -2549,10 +2549,10 @@ func TestPatchInferenceServiceSpec(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, false, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson)
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, false, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson)
 
 	one := 1
 	minReplica := 1
@@ -3215,7 +3215,7 @@ func TestCreateTransformerSpec(t *testing.T) {
 	memoryLimit.Add(memoryRequest)
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, false, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson)
 
 	modelSvc := &models.Service{
 		Name:         "model-1",

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -153,7 +153,8 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	tests := []struct {
 		name               string
@@ -1304,10 +1305,11 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
 								StorageURI: &storageUri,
 								Container: corev1.Container{
-									Name:      kserveconstant.InferenceServiceContainerName,
-									Resources: expDefaultModelResourceRequests,
-									Ports:     grpcContainerPorts,
-									Env:       []corev1.EnvVar{},
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     expDefaultModelResourceRequests,
+									Ports:         grpcContainerPorts,
+									Env:           []corev1.EnvVar{},
+									LivenessProbe: probeConfigUPI,
 								},
 							},
 						},
@@ -1359,11 +1361,12 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 						PodSpec: kservev1beta1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Name:      kserveconstant.InferenceServiceContainerName,
-									Image:     "gojek/project-model:1",
-									Resources: expDefaultModelResourceRequests,
-									Ports:     grpcContainerPorts,
-									Env:       createPyFuncDefaultEnvVarsWithProtocol(modelSvc, protocol.UpiV1).ToKubernetesEnvVars(),
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Image:         "gojek/project-model:1",
+									Resources:     expDefaultModelResourceRequests,
+									Ports:         grpcContainerPorts,
+									Env:           createPyFuncDefaultEnvVarsWithProtocol(modelSvc, protocol.UpiV1).ToKubernetesEnvVars(),
+									LivenessProbe: probeConfigUPI,
 								},
 							},
 						},
@@ -1412,10 +1415,11 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
 								StorageURI: &storageUri,
 								Container: corev1.Container{
-									Name:      kserveconstant.InferenceServiceContainerName,
-									Resources: expDefaultModelResourceRequests,
-									Ports:     grpcContainerPorts,
-									Env:       []corev1.EnvVar{},
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     expDefaultModelResourceRequests,
+									Ports:         grpcContainerPorts,
+									Env:           []corev1.EnvVar{},
+									LivenessProbe: probeConfigUPI,
 								},
 							},
 						},
@@ -1565,11 +1569,12 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec("/")
-
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
+	transformerProbeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, "/")
 	tests := []struct {
 		name     string
 		modelSvc *models.Service
@@ -1788,10 +1793,11 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
 								StorageURI: &storageUri,
 								Container: corev1.Container{
-									Name:      kserveconstant.InferenceServiceContainerName,
-									Resources: expDefaultModelResourceRequests,
-									Env:       []corev1.EnvVar{},
-									Ports:     grpcContainerPorts,
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     expDefaultModelResourceRequests,
+									Env:           []corev1.EnvVar{},
+									Ports:         grpcContainerPorts,
+									LivenessProbe: probeConfigUPI,
 								},
 							},
 						},
@@ -1804,13 +1810,14 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 						PodSpec: kservev1beta1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Name:      "transformer",
-									Image:     "ghcr.io/gojek/merlin-transformer-test",
-									Command:   []string{"python"},
-									Args:      []string{"main.py"},
-									Env:       createDefaultTransformerEnvVars(modelSvcGRPC).ToKubernetesEnvVars(),
-									Resources: expDefaultTransformerResourceRequests,
-									Ports:     grpcContainerPorts,
+									Name:          "transformer",
+									Image:         "ghcr.io/gojek/merlin-transformer-test",
+									Command:       []string{"python"},
+									Args:          []string{"main.py"},
+									Env:           createDefaultTransformerEnvVars(modelSvcGRPC).ToKubernetesEnvVars(),
+									Resources:     expDefaultTransformerResourceRequests,
+									LivenessProbe: transformerProbeConfigUPI,
+									Ports:         grpcContainerPorts,
 								},
 							},
 						},
@@ -1975,10 +1982,11 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
 								StorageURI: &storageUri,
 								Container: corev1.Container{
-									Name:      kserveconstant.InferenceServiceContainerName,
-									Resources: expDefaultModelResourceRequests,
-									Env:       []corev1.EnvVar{},
-									Ports:     grpcContainerPorts,
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     expDefaultModelResourceRequests,
+									Env:           []corev1.EnvVar{},
+									LivenessProbe: probeConfigUPI,
+									Ports:         grpcContainerPorts,
 								},
 							},
 						},
@@ -2009,8 +2017,9 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 										{Name: transformer.JaegerDisabled, Value: standardTransformerConfig.Jaeger.Disabled},
 										{Name: transformer.StandardTransformerConfigEnvName, Value: `{"standard_transformer":null}`},
 									}, createDefaultTransformerEnvVars(modelSvcGRPC)).ToKubernetesEnvVars(),
-									Resources: expDefaultTransformerResourceRequests,
-									Ports:     grpcContainerPorts,
+									Resources:     expDefaultTransformerResourceRequests,
+									Ports:         grpcContainerPorts,
+									LivenessProbe: transformerProbeConfigUPI,
 								},
 							},
 						},
@@ -2076,10 +2085,10 @@ func TestCreateInferenceServiceSpecWithLogger(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec("/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
 
 	tests := []struct {
 		name     string
@@ -2540,10 +2549,10 @@ func TestPatchInferenceServiceSpec(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec("/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
 
 	one := 1
 	minReplica := 1
@@ -3206,7 +3215,7 @@ func TestCreateTransformerSpec(t *testing.T) {
 	memoryLimit.Add(memoryRequest)
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec("/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
 
 	modelSvc := &models.Service{
 		Name:         "model-1",

--- a/api/pkg/transformer/server/grpc/healthcheck.go
+++ b/api/pkg/transformer/server/grpc/healthcheck.go
@@ -1,0 +1,27 @@
+package grpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+type healthChecker struct{}
+
+// Check
+func (s *healthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+// Watch performs a watch for the serving status of the requested service
+func (s *healthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
+	return server.Send(&grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	})
+}
+
+func newHealthChecker() *healthChecker {
+	return &healthChecker{}
+}

--- a/api/pkg/transformer/server/grpc/server.go
+++ b/api/pkg/transformer/server/grpc/server.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
@@ -115,6 +116,10 @@ func (us *UPIServer) Run() {
 	grpcServer := grpc.NewServer(opts...)
 	reflection.Register(grpcServer)
 	upiv1.RegisterUniversalPredictionServiceServer(grpcServer, us)
+
+	// add health check service
+	healthChecker := newHealthChecker()
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthChecker)
 
 	stopCh := setupSignalHandler()
 	errCh := make(chan error, 1)

--- a/api/pkg/transformer/server/grpc/server.go
+++ b/api/pkg/transformer/server/grpc/server.go
@@ -107,7 +107,8 @@ func (us *UPIServer) Run() {
 	}
 
 	m := cmux.New(lis)
-	grpcLis := m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+	// cmux.HTTP2MatchHeaderFieldSendSettings ensures we can handle any gRPC client.
+	grpcLis := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
 	httpLis := m.Match(cmux.HTTP1Fast())
 
 	opts := []grpc.ServerOption{

--- a/python/pyfunc-server/docker/base.Dockerfile
+++ b/python/pyfunc-server/docker/base.Dockerfile
@@ -26,7 +26,7 @@ ENV SDK_PATH=/sdk
 RUN conda env create -f /pyfunc-server/docker/env${PYTHON_VERSION}.yaml && \
     rm -rf /root/.cache
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.4 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 

--- a/python/pyfunc-server/docker/base.Dockerfile
+++ b/python/pyfunc-server/docker/base.Dockerfile
@@ -26,6 +26,11 @@ ENV SDK_PATH=/sdk
 RUN conda env create -f /pyfunc-server/docker/env${PYTHON_VERSION}.yaml && \
     rm -rf /root/.cache
 
+RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
+
+
 RUN mkdir /prom_dir
 ENV PROMETHEUS_MULTIPROC_DIR=/prom_dir
 # For backward compatibility

--- a/python/pyfunc-server/docker/base.Dockerfile
+++ b/python/pyfunc-server/docker/base.Dockerfile
@@ -26,10 +26,9 @@ ENV SDK_PATH=/sdk
 RUN conda env create -f /pyfunc-server/docker/env${PYTHON_VERSION}.yaml && \
     rm -rf /root/.cache
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.4 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.4
+RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
-
 
 RUN mkdir /prom_dir
 ENV PROMETHEUS_MULTIPROC_DIR=/prom_dir

--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -10,4 +10,5 @@ caraml-upi-protos
 grpcio<1.49.0
 grpcio-reflection<1.49.0
 grpcio-tools<1.49.0
+grpcio-health-checking<1.49.0
 file:${SDK_PATH}#egg=merlin-sdk

--- a/python/pyfunc-server/test/test_upi.py
+++ b/python/pyfunc-server/test/test_upi.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 from caraml.upi.utils import df_to_table
 from caraml.upi.v1 import upi_pb2, upi_pb2_grpc, variable_pb2, type_pb2
+from grpc_health.v1 import health_pb2_grpc, health_pb2
 from merlin.model import PyFuncModel
 from merlin.protocol import Protocol
 from prometheus_client import Counter, Gauge
@@ -64,6 +65,11 @@ def test_benchmark_multiprocess(workers, benchmark):
         c = start_upi_server(model_name, model_version, http_port, grpc_port, workers, metrics_path)
 
         channel = grpc.insecure_channel(f'localhost:{grpc_port}')
+        
+        health_check_stub = health_pb2_grpc.HealthStub(channel)
+        response: health_pb2.HealthCheckResponse = health_check_stub.Check(health_pb2.HealthCheckRequest())
+        assert response.status == health_pb2.HealthCheckResponse.SERVING
+
         stub = upi_pb2_grpc.UniversalPredictionServiceStub(channel)
         df = pd.DataFrame([[4, 1, "hi"]] * 3,
                           columns=['int_value', 'int_value_2', 'string_value'],
@@ -114,6 +120,11 @@ def test_upi(workers):
         c = start_upi_server(model_name, model_version, http_port, grpc_port, workers, metrics_path)
 
         channel = grpc.insecure_channel(f'localhost:{grpc_port}')
+
+        health_check_stub = health_pb2_grpc.HealthStub(channel)
+        response: health_pb2.HealthCheckResponse = health_check_stub.Check(health_pb2.HealthCheckRequest())
+        assert response.status == health_pb2.HealthCheckResponse.SERVING
+
         stub = upi_pb2_grpc.UniversalPredictionServiceStub(channel)
         df = pd.DataFrame([[4, 1, "hi"]] * 3,
                           columns=['int_value', 'int_value_2', 'string_value'],

--- a/transformer.Dockerfile
+++ b/transformer.Dockerfile
@@ -49,6 +49,11 @@ FROM alpine:3.12
 COPY --from=go-builder /src/api/bin/transformer /usr/bin/transformer
 COPY --from=go-builder /usr/local/go/lib/time/zoneinfo.zip /zoneinfo.zip
 
+# Adding the grpc_health_probe
+RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
+
 ENV ZONEINFO=/zoneinfo.zip
 
 ENTRYPOINT ["transformer"]

--- a/transformer.Dockerfile
+++ b/transformer.Dockerfile
@@ -50,8 +50,8 @@ COPY --from=go-builder /src/api/bin/transformer /usr/bin/transformer
 COPY --from=go-builder /usr/local/go/lib/time/zoneinfo.zip /zoneinfo.zip
 
 # Adding the grpc_health_probe
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.4 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.4
+RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 
 ENV ZONEINFO=/zoneinfo.zip

--- a/transformer.Dockerfile
+++ b/transformer.Dockerfile
@@ -50,7 +50,7 @@ COPY --from=go-builder /src/api/bin/transformer /usr/bin/transformer
 COPY --from=go-builder /usr/local/go/lib/time/zoneinfo.zip /zoneinfo.zip
 
 # Adding the grpc_health_probe
-RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.4 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Adding liveness probe for grpc service based on this [https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/](https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/). Transformer & pyfunc server will register grpc health service and using `exec` action for livenessprobe by running script from [https://github.com/grpc-ecosystem/grpc-health-probe/](https://github.com/grpc-ecosystem/grpc-health-probe/)
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
