### PR TITLE
Using istio_requests_count for error rate

### DIFF
--- a/api/models/model_endpoint_alert.go
+++ b/api/models/model_endpoint_alert.go
@@ -36,7 +36,7 @@ const (
 const (
 	throughputSliExprFormat    = "round(sum(rate(revision_request_count{cluster_name=\"%s\",namespace_name=\"%s\",revision_name=~\".*%s.*\"}[1m])), 0.001)"
 	latencySliExprFormat       = "histogram_quantile(%f, sum by(le, revision_name) (rate(revision_request_latencies_bucket{cluster_name=\"%s\",namespace_name=\"%s\",revision_name=~\".*%s.*\"}[1m])))"
-	errorRateSliExprFormat     = "(100 * sum(rate(revision_request_count{cluster_name=\"%s\",namespace_name=\"%s\",response_code_class!=\"2xx\",revision_name=~\".*%s.*\"}[1m])) / sum(rate(revision_request_count{cluster_name=\"%s\",namespace_name=\"%s\",revision_name=~\".*%s.*\"}[1m])))"
+	errorRateSliExprHTTPFormat = "(100 * sum(rate(istio_requests_total{cluster_name=\"%s\",destination_service_name=~\"%s.*\",destination_workload_namespace=\"%s\",response_code!=\"200\",request_protocol=\"http\"}[1m])) / sum(rate(istio_requests_total{cluster_name=\"%s\",destination_service_name=~\"%s.*\",destination_workload_namespace=\"%s\",request_protocol=\"http\"}[1m])))"
 	errorRateSliExprGRPCFormat = "(100 * sum(rate(istio_requests_total{cluster_name=\"%s\",destination_service_name=~\"%s.*\",destination_workload_namespace=\"%s\",grpc_response_status!=\"0\",request_protocol=\"grpc\"}[1m])) / sum(rate(istio_requests_total{cluster_name=\"%s\",destination_service_name=~\"%s.*\",destination_workload_namespace=\"%s\",request_protocol=\"grpc\"}[1m])))"
 	cpuSliExprFormat           = "(100 * sum(rate(container_cpu_usage_seconds_total{cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}[1m])) / sum(kube_pod_container_resource_requests{resource=\"cpu\",cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}))"
 	memorySliExprFormat        = "(100 * sum(container_memory_usage_bytes{cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}) / sum(kube_pod_container_resource_requests{resource=\"memory\",cluster_name=\"%s\",namespace=\"%s\",pod=~\".*%s.*\",container!~\"|POD\"}))"
@@ -188,9 +188,9 @@ func (alert ModelEndpointAlert) sliExpr(alertCondition AlertCondition) string {
 			)
 		}
 		return fmt.Sprintf(
-			errorRateSliExprFormat,
-			alert.ModelEndpoint.Environment.Cluster, alert.Model.Project.Name, alert.Model.Name,
-			alert.ModelEndpoint.Environment.Cluster, alert.Model.Project.Name, alert.Model.Name,
+			errorRateSliExprHTTPFormat,
+			alert.ModelEndpoint.Environment.Cluster, alert.Model.Name, alert.Model.Project.Name,
+			alert.ModelEndpoint.Environment.Cluster, alert.Model.Name, alert.Model.Project.Name,
 		)
 	case AlertConditionTypeCPU:
 		return fmt.Sprintf(

--- a/api/models/model_endpoint_alert_test.go
+++ b/api/models/model_endpoint_alert_test.go
@@ -217,7 +217,7 @@ func TestModelEndpointAlert_ToPromAlertSpec(t *testing.T) {
 									Kind:  yamlv3.ScalarNode,
 									Style: yamlv3.LiteralStyle,
 									Tag:   "!!str",
-									Value: "(100 * sum(rate(revision_request_count{cluster_name=\"cluster-1\",namespace_name=\"project-1\",response_code_class!=\"2xx\",revision_name=~\".*model-1.*\"}[1m])) / sum(rate(revision_request_count{cluster_name=\"cluster-1\",namespace_name=\"project-1\",revision_name=~\".*model-1.*\"}[1m]))) > 50",
+									Value: "(100 * sum(rate(istio_requests_total{cluster_name=\"cluster-1\",destination_service_name=~\"model-1.*\",destination_workload_namespace=\"project-1\",request_protocol=\"http\",response_code!=\"200\"}[1m])) / sum(rate(istio_requests_total{cluster_name=\"cluster-1\",destination_service_name=~\"model-1.*\",destination_workload_namespace=\"project-1\",request_protocol=\"http\"}[1m]))) > 50",
 								},
 								For: "5m",
 								Labels: PromAlertRuleLabels{

--- a/api/service/testdata/model_endpoint_alert.yaml
+++ b/api/service/testdata/model_endpoint_alert.yaml
@@ -75,7 +75,7 @@ groups:
             summary: 95.00p latency of model-1 model ({{ $labels.revision_name }}) in env-1 is higher than 6.00 ms. Current value is {{ $value }} ms.
         - alert: "[merlin] model-1: Error Rate warning"
           expr: |-
-            (100 * sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",response_code_class!="2xx",revision_name=~".*model-1.*"}[1m])) / sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 7
+            (100 * sum(rate(istio_requests_total{cluster_name="cluster-1",destination_service_name=~"model-1.*",destination_workload_namespace="project-1",request_protocol="http",response_code!="200"}[1m])) / sum(rate(istio_requests_total{cluster_name="cluster-1",destination_service_name=~"model-1.*",destination_workload_namespace="project-1",request_protocol="http"}[1m]))) > 7
           for: 5m
           labels:
             owner: team-1
@@ -87,7 +87,7 @@ groups:
             summary: Error rate of model-1 model in env-1 is higher than 7.00%. Current value is {{ $value }}%.
         - alert: "[merlin] model-1: Error Rate critical"
           expr: |-
-            (100 * sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",response_code_class!="2xx",revision_name=~".*model-1.*"}[1m])) / sum(rate(revision_request_count{cluster_name="cluster-1",namespace_name="project-1",revision_name=~".*model-1.*"}[1m]))) > 8
+            (100 * sum(rate(istio_requests_total{cluster_name="cluster-1",destination_service_name=~"model-1.*",destination_workload_namespace="project-1",request_protocol="http",response_code!="200"}[1m])) / sum(rate(istio_requests_total{cluster_name="cluster-1",destination_service_name=~"model-1.*",destination_workload_namespace="project-1",request_protocol="http"}[1m]))) > 8
           for: 5m
           labels:
             owner: team-1


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Previously we use different metrics for getting error rate, using `istio_requests_count` for grpc and `revision_request_count` for http, since `istio_requests_count` can be used for http error rate, so we rely on the same metric for error rate
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
