### PR TITLE
Update mlp deployment in CI to use charts from caraml

### DIFF
--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -363,14 +363,14 @@ jobs:
         with:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
-      - name: Download API Docker Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: merlin.${{ needs.create-version.outputs.version }}.tar
-      - name: Download Standard Transformer Docker Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: merlin-transformer.${{ needs.create-version.outputs.version }}.tar
+      # - name: Download API Docker Artifact
+      #   uses: actions/download-artifact@v2
+      #   with:
+      #     name: merlin.${{ needs.create-version.outputs.version }}.tar
+      # - name: Download Standard Transformer Docker Artifact
+      #   uses: actions/download-artifact@v2
+      #   with:
+      #     name: merlin-transformer.${{ needs.create-version.outputs.version }}.tar
       - name: Download k3d
         run: |
           curl --silent --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.4.1 bash
@@ -378,17 +378,17 @@ jobs:
         run: |
           k3d registry create $LOCAL_REGISTRY --port $LOCAL_REGISTRY_PORT
           k3d cluster create $K3D_CLUSTER --image rancher/k3s:v1.21.2-k3s1 --k3s-arg '--no-deploy=traefik,metrics-server@server:*' --port 80:80@loadbalancer
-      - name: Publish images to k3d registry
-        run: |
-          # Merlin API
-          docker image load --input merlin.${{ needs.create-version.outputs.version }}.tar
-          docker tag merlin:${{ needs.create-version.outputs.version }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin:${{ needs.create-version.outputs.version }}
-          k3d image import ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin:${{ needs.create-version.outputs.version }} -c merlin-cluster
+      # - name: Publish images to k3d registry
+      #   run: |
+      #     # Merlin API
+      #     docker image load --input merlin.${{ needs.create-version.outputs.version }}.tar
+      #     docker tag merlin:${{ needs.create-version.outputs.version }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin:${{ needs.create-version.outputs.version }}
+      #     k3d image import ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin:${{ needs.create-version.outputs.version }} -c merlin-cluster
 
-          # Standard Transformer
-          docker image load --input  merlin-transformer.${{ needs.create-version.outputs.version }}.tar
-          docker tag merlin-transformer:${{ needs.create-version.outputs.version }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin-transformer:${{ needs.create-version.outputs.version }}
-          k3d image import ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin-transformer:${{ needs.create-version.outputs.version }} -c merlin-cluster
+      #     # Standard Transformer
+      #     docker image load --input  merlin-transformer.${{ needs.create-version.outputs.version }}.tar
+      #     docker tag merlin-transformer:${{ needs.create-version.outputs.version }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin-transformer:${{ needs.create-version.outputs.version }}
+      #     k3d image import ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin-transformer:${{ needs.create-version.outputs.version }} -c merlin-cluster
       - name: Setup cluster
         working-directory: merlin/scripts/e2e
         run: ./setup-cluster.sh merlin-cluster ${{ env.INGRESS_HOST }}

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -332,25 +332,21 @@ jobs:
   e2e-test:
     runs-on: ubuntu-latest
     needs:
-      - build-api
-      - build-batch-predictor
-      - build-pyfunc-server
-      - build-transformer
+    #   - build-api
+    #   - build-batch-predictor
+    #   - build-pyfunc-server
+    #   - build-transformer
       - create-version
     env:
       K3D_CLUSTER: merlin-cluster
       LOCAL_REGISTRY_PORT: 12345
       LOCAL_REGISTRY: "dev.localhost"
       INGRESS_HOST: "127.0.0.1.nip.io"
+      MLP_CHART_VERSION: 0.3.3
     steps:
       - uses: actions/checkout@v2
         with:
           path: merlin
-      - uses: actions/checkout@master
-        with:
-          repository: gojek/mlp
-          ref: v1.7.4
-          path: merlin/scripts/e2e/mlp
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -398,7 +394,7 @@ jobs:
         run: ./setup-cluster.sh merlin-cluster ${{ env.INGRESS_HOST }}
       - name: Deploy merlin and mlp
         working-directory: merlin/scripts/e2e
-        run: ./deploy-merlin.sh ${{ env.INGRESS_HOST }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }} ../../charts/merlin ${{ needs.create-version.outputs.version }} ${{ github.ref }}
+        run: ./deploy-merlin.sh ${{ env.INGRESS_HOST }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }} ../../charts/merlin ${{ needs.create-version.outputs.version }} ${{ github.ref }} ${{ env.MLP_CHART_VERSION }}
       - name: Run E2E Test
         timeout-minutes: 30
         id: run-e2e-test

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -342,7 +342,7 @@ jobs:
       LOCAL_REGISTRY_PORT: 12345
       LOCAL_REGISTRY: "dev.localhost"
       INGRESS_HOST: "127.0.0.1.nip.io"
-      MLP_CHART_VERSION: 0.3.3
+      MLP_CHART_VERSION: 0.3.4
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -332,10 +332,10 @@ jobs:
   e2e-test:
     runs-on: ubuntu-latest
     needs:
-    #   - build-api
-    #   - build-batch-predictor
-    #   - build-pyfunc-server
-    #   - build-transformer
+      - build-api
+      - build-batch-predictor
+      - build-pyfunc-server
+      - build-transformer
       - create-version
     env:
       K3D_CLUSTER: merlin-cluster
@@ -363,14 +363,14 @@ jobs:
         with:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
-      # - name: Download API Docker Artifact
-      #   uses: actions/download-artifact@v2
-      #   with:
-      #     name: merlin.${{ needs.create-version.outputs.version }}.tar
-      # - name: Download Standard Transformer Docker Artifact
-      #   uses: actions/download-artifact@v2
-      #   with:
-      #     name: merlin-transformer.${{ needs.create-version.outputs.version }}.tar
+      - name: Download API Docker Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: merlin.${{ needs.create-version.outputs.version }}.tar
+      - name: Download Standard Transformer Docker Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: merlin-transformer.${{ needs.create-version.outputs.version }}.tar
       - name: Download k3d
         run: |
           curl --silent --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.4.1 bash
@@ -378,17 +378,17 @@ jobs:
         run: |
           k3d registry create $LOCAL_REGISTRY --port $LOCAL_REGISTRY_PORT
           k3d cluster create $K3D_CLUSTER --image rancher/k3s:v1.21.2-k3s1 --k3s-arg '--no-deploy=traefik,metrics-server@server:*' --port 80:80@loadbalancer
-      # - name: Publish images to k3d registry
-      #   run: |
-      #     # Merlin API
-      #     docker image load --input merlin.${{ needs.create-version.outputs.version }}.tar
-      #     docker tag merlin:${{ needs.create-version.outputs.version }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin:${{ needs.create-version.outputs.version }}
-      #     k3d image import ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin:${{ needs.create-version.outputs.version }} -c merlin-cluster
+      - name: Publish images to k3d registry
+        run: |
+          # Merlin API
+          docker image load --input merlin.${{ needs.create-version.outputs.version }}.tar
+          docker tag merlin:${{ needs.create-version.outputs.version }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin:${{ needs.create-version.outputs.version }}
+          k3d image import ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin:${{ needs.create-version.outputs.version }} -c merlin-cluster
 
-      #     # Standard Transformer
-      #     docker image load --input  merlin-transformer.${{ needs.create-version.outputs.version }}.tar
-      #     docker tag merlin-transformer:${{ needs.create-version.outputs.version }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin-transformer:${{ needs.create-version.outputs.version }}
-      #     k3d image import ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin-transformer:${{ needs.create-version.outputs.version }} -c merlin-cluster
+          # Standard Transformer
+          docker image load --input  merlin-transformer.${{ needs.create-version.outputs.version }}.tar
+          docker tag merlin-transformer:${{ needs.create-version.outputs.version }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin-transformer:${{ needs.create-version.outputs.version }}
+          k3d image import ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }}/merlin-transformer:${{ needs.create-version.outputs.version }} -c merlin-cluster
       - name: Setup cluster
         working-directory: merlin/scripts/e2e
         run: ./setup-cluster.sh merlin-cluster ${{ env.INGRESS_HOST }}

--- a/scripts/e2e/deploy-merlin.sh
+++ b/scripts/e2e/deploy-merlin.sh
@@ -19,15 +19,16 @@ install_mlp() {
   echo "::group::MLP Deployment"
 
   helm repo add caraml https://caraml-dev.github.io/helm-charts
-  
+
   helm upgrade --install --debug mlp caraml/mlp --namespace mlp --create-namespace \
     --version ${MLP_CHART_VERSION} \
-    --set mlp.apiHost=http://mlp.mlp.${INGRESS_HOST}/v1 \
-    --set mlp.mlflowTrackingUrl=http://mlflow.mlp.${INGRESS_HOST} \
-    --set mlp.ingress.enabled=true \
-    --set mlp.ingress.class=istio \
-    --set mlp.ingress.path="/*" \
-    --set mlp.ingress.host=mlp.mlp.${INGRESS_HOST} \
+    --set fullnameOverride=mlp \
+    --set deployment.apiHost=http://mlp.mlp.${INGRESS_HOST}/v1 \
+    --set deployment.mlflowTrackingUrl=http://mlflow.mlp.${INGRESS_HOST} \
+    --set ingress.enabled=true \
+    --set ingress.class=istio \
+    --set ingress.path="/*" \
+    --set ingress.host=mlp.mlp.${INGRESS_HOST} \
     --wait --timeout=${TIMEOUT}
 
    kubectl apply -f config/mock/message-dumper.yaml

--- a/scripts/e2e/deploy-merlin.sh
+++ b/scripts/e2e/deploy-merlin.sh
@@ -10,14 +10,18 @@ DOCKER_REGISTRY="$2"
 CHART_PATH="$3"
 VERSION="$4"
 GIT_REF="$5"
+MLP_CHART_VERSION="$6"
 
 
 TIMEOUT=120s
 
 install_mlp() {
   echo "::group::MLP Deployment"
-  helm upgrade --install --debug mlp mlp/charts/mlp --namespace mlp --create-namespace -f mlp/charts/mlp/values-e2e.yaml \
-    --set mlp.image.tag=v1.7.4 \
+
+  helm repo add caraml https://caraml-dev.github.io/helm-charts
+  
+  helm upgrade --install --debug mlp caraml/mlp --namespace mlp --create-namespace \
+    --version ${MLP_CHART_VERSION} \
     --set mlp.apiHost=http://mlp.mlp.${INGRESS_HOST}/v1 \
     --set mlp.mlflowTrackingUrl=http://mlflow.mlp.${INGRESS_HOST} \
     --set mlp.ingress.enabled=true \

--- a/scripts/e2e/deploy-merlin.sh
+++ b/scripts/e2e/deploy-merlin.sh
@@ -27,6 +27,7 @@ install_mlp() {
     --set deployment.mlflowTrackingUrl=http://mlflow.mlp.${INGRESS_HOST} \
     --set ingress.enabled=true \
     --set ingress.class=istio \
+    --set ingress.pathType: ImplementationSpecific \
     --set ingress.host=mlp.mlp.${INGRESS_HOST} \
     --wait --timeout=${TIMEOUT}
 

--- a/scripts/e2e/deploy-merlin.sh
+++ b/scripts/e2e/deploy-merlin.sh
@@ -27,7 +27,6 @@ install_mlp() {
     --set deployment.mlflowTrackingUrl=http://mlflow.mlp.${INGRESS_HOST} \
     --set ingress.enabled=true \
     --set ingress.class=istio \
-    --set ingress.pathType: ImplementationSpecific \
     --set ingress.host=mlp.mlp.${INGRESS_HOST} \
     --wait --timeout=${TIMEOUT}
 

--- a/scripts/e2e/deploy-merlin.sh
+++ b/scripts/e2e/deploy-merlin.sh
@@ -27,7 +27,6 @@ install_mlp() {
     --set deployment.mlflowTrackingUrl=http://mlflow.mlp.${INGRESS_HOST} \
     --set ingress.enabled=true \
     --set ingress.class=istio \
-    --set ingress.path="/*" \
     --set ingress.host=mlp.mlp.${INGRESS_HOST} \
     --wait --timeout=${TIMEOUT}
 

--- a/scripts/quick_install.sh
+++ b/scripts/quick_install.sh
@@ -12,7 +12,7 @@ export VAULT_VERSION=0.7.0
 export MINIO_VERSION=7.0.2
 
 export OAUTH_CLIENT_ID="<put your oauth client id here>"
-export MLP_CHART_VERSION=0.3.3
+export MLP_CHART_VERSION=0.3.4
 export MERLIN_VERSION=v0.9.0
 
 # Install Istio

--- a/scripts/quick_install.sh
+++ b/scripts/quick_install.sh
@@ -12,6 +12,7 @@ export VAULT_VERSION=0.7.0
 export MINIO_VERSION=7.0.2
 
 export OAUTH_CLIENT_ID="<put your oauth client id here>"
+export MLP_CHART_VERSION=0.3.3
 export MERLIN_VERSION=v0.9.0
 
 # Install Istio
@@ -177,16 +178,16 @@ helm install minio minio/minio --version=${MINIO_VERSION} --namespace=minio --va
 # Install MLP
 kubectl create namespace mlp
 
-git clone git@github.com:gojek/mlp.git
+helm repo add caraml https://caraml-dev.github.io/helm-charts
 
-helm install mlp ./mlp/chart --namespace=mlp --values=./mlp/chart/values-e2e.yaml \
-  --set mlp.image.tag=main \
-  --set mlp.apiHost=http://mlp.mlp.${INGRESS_HOST}.nip.io/v1 \
-  --set mlp.oauthClientID=${OAUTH_CLIENT_ID} \
-  --set mlp.mlflowTrackingUrl=http://mlflow.mlp.${INGRESS_HOST}.nip.io \
-  --set mlp.ingress.enabled=true \
-  --set mlp.ingress.class=istio \
-  --set mlp.ingress.host=mlp.mlp.${INGRESS_HOST}.nip.io \
+helm upgrade --install --debug mlp caraml/mlp --namespace mlp --create-namespace \
+  --version ${MLP_CHART_VERSION} \
+  --set fullnameOverride=mlp \
+  --set deployment.apiHost=http://mlp.mlp.${INGRESS_HOST}.nip.io/v1 \
+  --set deployment.mlflowTrackingUrl=http://mlflow.mlp.${INGRESS_HOST}.nip.io \
+  --set ingress.enabled=true \
+  --set ingress.class=istio \
+  --set ingress.host=mlp.mlp.${INGRESS_HOST}.nip.io \
   --wait --timeout=5m
 
 cat <<EOF > mlp-ingress.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
As part of the effort to stream line components across caraml products, helm charts for building mlp has been shifted to https://github.com/caraml-dev/helm-charts

This PR updates the CI to use the charts from there.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
