### PR TITLE
Add labels for kaniko created pods

### DIFF
--- a/api/pkg/imagebuilder/imagebuilder.go
+++ b/api/pkg/imagebuilder/imagebuilder.go
@@ -75,7 +75,7 @@ const (
 	labelAppName          = "gojek.com/app"
 	labelEnvironment      = "gojek.com/environment"
 	labelOrchestratorName = "gojek.com/orchestrator"
-	labelComponent 		  = "gojek.com/component"
+	labelComponent        = "gojek.com/component"
 )
 
 var (
@@ -345,7 +345,7 @@ func (c *imageBuilder) createKanikoJobSpec(project mlp.Project, model *models.Mo
 		labelAppName:          model.Name,
 		labelEnvironment:      c.config.Environment,
 		labelOrchestratorName: "merlin",
-		labelComponent:		   "image-builder"
+		labelComponent:        "image-builder",
 	}
 
 	baseImageTag, ok := c.config.BaseImages[version.PythonVersion]

--- a/api/pkg/imagebuilder/imagebuilder.go
+++ b/api/pkg/imagebuilder/imagebuilder.go
@@ -75,6 +75,7 @@ const (
 	labelAppName          = "gojek.com/app"
 	labelEnvironment      = "gojek.com/environment"
 	labelOrchestratorName = "gojek.com/orchestrator"
+	labelComponent 		  = "gojek.com/component"
 )
 
 var (
@@ -344,6 +345,7 @@ func (c *imageBuilder) createKanikoJobSpec(project mlp.Project, model *models.Mo
 		labelAppName:          model.Name,
 		labelEnvironment:      c.config.Environment,
 		labelOrchestratorName: "merlin",
+		labelComponent:		   "image-builder"
 	}
 
 	baseImageTag, ok := c.config.BaseImages[version.PythonVersion]
@@ -379,6 +381,11 @@ func (c *imageBuilder) createKanikoJobSpec(project mlp.Project, model *models.Mo
 			TTLSecondsAfterFinished: &jobTTLSecondAfterComplete,
 			ActiveDeadlineSeconds:   &activeDeadlineSeconds,
 			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kanikoPodName,
+					Namespace: c.config.BuildNamespace,
+					Labels:    labels,
+				},
 				Spec: v1.PodSpec{
 					// https://stackoverflow.com/questions/54091659/kubernetes-pods-disappear-after-failed-jobs
 					RestartPolicy: v1.RestartPolicyNever,

--- a/api/pkg/imagebuilder/imagebuilder.go
+++ b/api/pkg/imagebuilder/imagebuilder.go
@@ -382,9 +382,7 @@ func (c *imageBuilder) createKanikoJobSpec(project mlp.Project, model *models.Mo
 			ActiveDeadlineSeconds:   &activeDeadlineSeconds,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      kanikoPodName,
-					Namespace: c.config.BuildNamespace,
-					Labels:    labels,
+					Labels: labels,
 				},
 				Spec: v1.PodSpec{
 					// https://stackoverflow.com/questions/54091659/kubernetes-pods-disappear-after-failed-jobs

--- a/api/pkg/imagebuilder/imagebuilder_test.go
+++ b/api/pkg/imagebuilder/imagebuilder_test.go
@@ -159,6 +159,7 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
 						"gojek.com/environment":  config.Environment,
+						"gojek.com/component":    "image-builder",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -167,6 +168,18 @@ func TestBuildImage(t *testing.T) {
 					TTLSecondsAfterFinished: &jobTTLSecondAfterComplete,
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
+							Namespace: config.BuildNamespace,
+							Labels: map[string]string{
+								"gojek.com/app":          model.Name,
+								"gojek.com/orchestrator": "merlin",
+								"gojek.com/stream":       project.Stream,
+								"gojek.com/team":         project.Team,
+								"gojek.com/environment":  config.Environment,
+								"gojek.com/component":    "image-builder",
+							},
+						},
 						Spec: v1.PodSpec{
 							RestartPolicy: v1.RestartPolicyNever,
 							Containers: []v1.Container{
@@ -249,6 +262,7 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
 						"gojek.com/environment":  config.Environment,
+						"gojek.com/component":    "image-builder",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -257,6 +271,18 @@ func TestBuildImage(t *testing.T) {
 					TTLSecondsAfterFinished: &jobTTLSecondAfterComplete,
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
+							Namespace: config.BuildNamespace,
+							Labels: map[string]string{
+								"gojek.com/app":          model.Name,
+								"gojek.com/orchestrator": "merlin",
+								"gojek.com/stream":       project.Stream,
+								"gojek.com/team":         project.Team,
+								"gojek.com/environment":  config.Environment,
+								"gojek.com/component":    "image-builder",
+							},
+						},
 						Spec: v1.PodSpec{
 							RestartPolicy: v1.RestartPolicyNever,
 							Containers: []v1.Container{
@@ -366,6 +392,7 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
 						"gojek.com/environment":  config.Environment,
+						"gojek.com/component":    "image-builder",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -374,6 +401,18 @@ func TestBuildImage(t *testing.T) {
 					TTLSecondsAfterFinished: &jobTTLSecondAfterComplete,
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
+							Namespace: config.BuildNamespace,
+							Labels: map[string]string{
+								"gojek.com/app":          model.Name,
+								"gojek.com/orchestrator": "merlin",
+								"gojek.com/stream":       project.Stream,
+								"gojek.com/team":         project.Team,
+								"gojek.com/environment":  config.Environment,
+								"gojek.com/component":    "image-builder",
+							},
+						},
 						Spec: v1.PodSpec{
 							RestartPolicy: v1.RestartPolicyNever,
 							Containers: []v1.Container{
@@ -493,6 +532,7 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
 						"gojek.com/environment":  config.Environment,
+						"gojek.com/component":    "image-builder",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -501,6 +541,18 @@ func TestBuildImage(t *testing.T) {
 					TTLSecondsAfterFinished: &jobTTLSecondAfterComplete,
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
+							Namespace: config.BuildNamespace,
+							Labels: map[string]string{
+								"gojek.com/app":          model.Name,
+								"gojek.com/orchestrator": "merlin",
+								"gojek.com/stream":       project.Stream,
+								"gojek.com/team":         project.Team,
+								"gojek.com/environment":  config.Environment,
+								"gojek.com/component":    "image-builder",
+							},
+						},
 						Spec: v1.PodSpec{
 							RestartPolicy: v1.RestartPolicyNever,
 							Containers: []v1.Container{
@@ -614,6 +666,7 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
 						"gojek.com/environment":  config.Environment,
+						"gojek.com/component":    "image-builder",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -622,6 +675,18 @@ func TestBuildImage(t *testing.T) {
 					TTLSecondsAfterFinished: &jobTTLSecondAfterComplete,
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
+							Namespace: config.BuildNamespace,
+							Labels: map[string]string{
+								"gojek.com/app":          model.Name,
+								"gojek.com/orchestrator": "merlin",
+								"gojek.com/stream":       project.Stream,
+								"gojek.com/team":         project.Team,
+								"gojek.com/environment":  config.Environment,
+								"gojek.com/component":    "image-builder",
+							},
+						},
 						Spec: v1.PodSpec{
 							RestartPolicy: v1.RestartPolicyNever,
 							Containers: []v1.Container{
@@ -703,6 +768,7 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
 						"gojek.com/environment":  config.Environment,
+						"gojek.com/component":    "image-builder",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -711,6 +777,18 @@ func TestBuildImage(t *testing.T) {
 					TTLSecondsAfterFinished: &jobTTLSecondAfterComplete,
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
+							Namespace: config.BuildNamespace,
+							Labels: map[string]string{
+								"gojek.com/app":          model.Name,
+								"gojek.com/orchestrator": "merlin",
+								"gojek.com/stream":       project.Stream,
+								"gojek.com/team":         project.Team,
+								"gojek.com/environment":  config.Environment,
+								"gojek.com/component":    "image-builder",
+							},
+						},
 						Spec: v1.PodSpec{
 							RestartPolicy: v1.RestartPolicyNever,
 							Containers: []v1.Container{
@@ -795,6 +873,7 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
 						"gojek.com/environment":  config.Environment,
+						"gojek.com/component":    "image-builder",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -803,6 +882,18 @@ func TestBuildImage(t *testing.T) {
 					TTLSecondsAfterFinished: &jobTTLSecondAfterComplete,
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
+							Namespace: config.BuildNamespace,
+							Labels: map[string]string{
+								"gojek.com/app":          model.Name,
+								"gojek.com/orchestrator": "merlin",
+								"gojek.com/stream":       project.Stream,
+								"gojek.com/team":         project.Team,
+								"gojek.com/environment":  config.Environment,
+								"gojek.com/component":    "image-builder",
+							},
+						},
 						Spec: v1.PodSpec{
 							RestartPolicy: v1.RestartPolicyNever,
 							Containers: []v1.Container{
@@ -875,6 +966,7 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
 						"gojek.com/environment":  config.Environment,
+						"gojek.com/component":    "image-builder",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -883,6 +975,18 @@ func TestBuildImage(t *testing.T) {
 					TTLSecondsAfterFinished: &jobTTLSecondAfterComplete,
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
+							Namespace: config.BuildNamespace,
+							Labels: map[string]string{
+								"gojek.com/app":          model.Name,
+								"gojek.com/orchestrator": "merlin",
+								"gojek.com/stream":       project.Stream,
+								"gojek.com/team":         project.Team,
+								"gojek.com/environment":  config.Environment,
+								"gojek.com/component":    "image-builder",
+							},
+						},
 						Spec: v1.PodSpec{
 							RestartPolicy: v1.RestartPolicyNever,
 							Containers: []v1.Container{

--- a/api/pkg/imagebuilder/imagebuilder_test.go
+++ b/api/pkg/imagebuilder/imagebuilder_test.go
@@ -169,8 +169,6 @@ func TestBuildImage(t *testing.T) {
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
-							Namespace: config.BuildNamespace,
 							Labels: map[string]string{
 								"gojek.com/app":          model.Name,
 								"gojek.com/orchestrator": "merlin",
@@ -272,8 +270,6 @@ func TestBuildImage(t *testing.T) {
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
-							Namespace: config.BuildNamespace,
 							Labels: map[string]string{
 								"gojek.com/app":          model.Name,
 								"gojek.com/orchestrator": "merlin",
@@ -402,8 +398,6 @@ func TestBuildImage(t *testing.T) {
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
-							Namespace: config.BuildNamespace,
 							Labels: map[string]string{
 								"gojek.com/app":          model.Name,
 								"gojek.com/orchestrator": "merlin",
@@ -542,8 +536,6 @@ func TestBuildImage(t *testing.T) {
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
-							Namespace: config.BuildNamespace,
 							Labels: map[string]string{
 								"gojek.com/app":          model.Name,
 								"gojek.com/orchestrator": "merlin",
@@ -676,8 +668,6 @@ func TestBuildImage(t *testing.T) {
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
-							Namespace: config.BuildNamespace,
 							Labels: map[string]string{
 								"gojek.com/app":          model.Name,
 								"gojek.com/orchestrator": "merlin",
@@ -778,8 +768,6 @@ func TestBuildImage(t *testing.T) {
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
-							Namespace: config.BuildNamespace,
 							Labels: map[string]string{
 								"gojek.com/app":          model.Name,
 								"gojek.com/orchestrator": "merlin",
@@ -883,8 +871,6 @@ func TestBuildImage(t *testing.T) {
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
-							Namespace: config.BuildNamespace,
 							Labels: map[string]string{
 								"gojek.com/app":          model.Name,
 								"gojek.com/orchestrator": "merlin",
@@ -976,8 +962,6 @@ func TestBuildImage(t *testing.T) {
 					ActiveDeadlineSeconds:   &timeoutInSecond,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("%s-%s-%s", project.Name, model.Name, modelVersion.ID),
-							Namespace: config.BuildNamespace,
 							Labels: map[string]string{
 								"gojek.com/app":          model.Name,
 								"gojek.com/orchestrator": "merlin",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Add labels to kaniko image builder created pods for building images to reflect cost used by teams
Before (no gojek.com labels):
<img width="587" alt="image" src="https://user-images.githubusercontent.com/2015748/201707640-0db9618b-7632-4569-a8ec-617be7a20288.png">

After (with gojek.com labels:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/2015748/201707253-5c7a53e5-5fdc-41c0-b346-f251ed5d6d52.png">


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add labels for kaniko created pods 
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
