### PR TITLE
Differentiate error handling in standard transformer

### DIFF
--- a/api/pkg/errors/errors.go
+++ b/api/pkg/errors/errors.go
@@ -6,7 +6,8 @@ import (
 )
 
 var (
-	InvalidInputError error = errors.New("invalid input")
+	InvalidInputError     error = errors.New("invalid input")
+	DeadlineExceededError error = errors.New("deadline exceeded")
 )
 
 // NewInvalidInputError create new InvalidInputError with specified reason
@@ -19,4 +20,14 @@ func NewInvalidInputError(reason string) error {
 // errors.Is(error, InvalidInputError) will return true if a new error is created using this function
 func NewInvalidInputErrorf(reasonFormat string, a ...interface{}) error {
 	return fmt.Errorf("%w: %s", InvalidInputError, fmt.Sprintf(reasonFormat, a...))
+}
+
+// NewDeadlineExceededError create new DeadlineExceededError with specified reason
+func NewDeadlineExceededError(reason string) error {
+	return fmt.Errorf("%w: %s", DeadlineExceededError, reason)
+}
+
+// NewDeadlineExceededErrorf reate new DeadlineExceededError with specified reason string format
+func NewDeadlineExceededErrorf(reasonFormat string, a ...interface{}) error {
+	return fmt.Errorf("%w: %s", DeadlineExceededError, fmt.Sprintf(reasonFormat, a...))
 }

--- a/api/pkg/errors/errors.go
+++ b/api/pkg/errors/errors.go
@@ -27,7 +27,7 @@ func NewDeadlineExceededError(reason string) error {
 	return fmt.Errorf("%w: %s", DeadlineExceededError, reason)
 }
 
-// NewDeadlineExceededErrorf reate new DeadlineExceededError with specified reason string format
+// NewDeadlineExceededErrorf create new DeadlineExceededError with specified reason string format
 func NewDeadlineExceededErrorf(reasonFormat string, a ...interface{}) error {
 	return fmt.Errorf("%w: %s", DeadlineExceededError, fmt.Sprintf(reasonFormat, a...))
 }

--- a/api/pkg/transformer/executor/transformer_test.go
+++ b/api/pkg/transformer/executor/transformer_test.go
@@ -215,7 +215,7 @@ func TestStandardTransformer_Execute(t *testing.T) {
 			requestHeaders: map[string]string{
 				"Country-ID": "ID",
 			},
-			wantResponseByte: []byte(`{"response":{"error":"error executing preprocess operation: *pipeline.CreateTableOp: unable to create base table for entity_table: invalid json pointed by $.entities[*]: not an array"},"operation_tracing":null}`),
+			wantResponseByte: []byte(`{"response":{"error":"error executing preprocess operation: *pipeline.CreateTableOp: unable to create base table for entity_table: invalid json pointed by $.entities[*]: invalid input: not an array"},"operation_tracing":null}`),
 		},
 		{
 			desc:         "table transformation with conditional update, filter row and slice row",

--- a/api/pkg/transformer/feast/feature_retriever_test.go
+++ b/api/pkg/transformer/feast/feature_retriever_test.go
@@ -2653,7 +2653,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest_FeastTimeout(t *testi
 
 	got, err := fr.RetrieveFeatureOfEntityInRequest(context.Background(), requestJson)
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "hystrix: timeout")
+	assert.EqualError(t, err, "deadline exceeded: hystrix: timeout")
 
 	want := []*transTypes.FeatureTable{}
 	assert.ElementsMatch(t, got, want)

--- a/api/pkg/transformer/pipeline/create_table_op.go
+++ b/api/pkg/transformer/pipeline/create_table_op.go
@@ -146,7 +146,7 @@ func toRawTable(jsonObj interface{}, addRowNumber bool) (map[string]interface{},
 	for idx, j := range jsonArray {
 		node, ok := j.(map[string]interface{})
 		if !ok {
-			return nil, mErrors.NewInvalidInputError("not an array of object")
+			return nil, mErrors.NewInvalidInputError("not an array of objects")
 		}
 		for k, v := range node {
 			ss, ok := rawTable[k]

--- a/api/pkg/transformer/pipeline/create_table_op.go
+++ b/api/pkg/transformer/pipeline/create_table_op.go
@@ -146,7 +146,7 @@ func toRawTable(jsonObj interface{}, addRowNumber bool) (map[string]interface{},
 	for idx, j := range jsonArray {
 		node, ok := j.(map[string]interface{})
 		if !ok {
-			return nil, mErrors.NewInvalidInputError("not an array of JSON object")
+			return nil, mErrors.NewInvalidInputError("not an array of object")
 		}
 		for k, v := range node {
 			ss, ok := rawTable[k]

--- a/api/pkg/transformer/pipeline/create_table_op.go
+++ b/api/pkg/transformer/pipeline/create_table_op.go
@@ -2,9 +2,9 @@ package pipeline
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	mErrors "github.com/gojek/merlin/pkg/errors"
 	"github.com/gojek/merlin/pkg/transformer/spec"
 	"github.com/gojek/merlin/pkg/transformer/types"
 	"github.com/gojek/merlin/pkg/transformer/types/table"
@@ -135,7 +135,7 @@ func overrideColumns(env *Environment, t *table.Table, columns []*spec.Column) (
 func toRawTable(jsonObj interface{}, addRowNumber bool) (map[string]interface{}, error) {
 	jsonArray, ok := jsonObj.([]interface{})
 	if !ok {
-		return nil, errors.New("not an array")
+		return nil, mErrors.NewInvalidInputErrorf("not an array")
 	}
 
 	nrow := len(jsonArray)
@@ -146,7 +146,7 @@ func toRawTable(jsonObj interface{}, addRowNumber bool) (map[string]interface{},
 	for idx, j := range jsonArray {
 		node, ok := j.(map[string]interface{})
 		if !ok {
-			return nil, errors.New("not an array of JSON object")
+			return nil, mErrors.NewInvalidInputError("not an array of JSON object")
 		}
 		for k, v := range node {
 			ss, ok := rawTable[k]

--- a/api/pkg/transformer/pipeline/create_table_op_test.go
+++ b/api/pkg/transformer/pipeline/create_table_op_test.go
@@ -573,7 +573,7 @@ func TestCreateTableOp_Execute(t *testing.T) {
 			},
 			env:          env,
 			wantErr:      true,
-			errorPattern: `unable to create base table for my_table: invalid json pointed by \$\.unknown_field: not an array`,
+			errorPattern: `unable to create base table for my_table: invalid json pointed by \$\.unknown_field: invalid input: not an array`,
 		},
 		{
 			name: "create table from json path: not an array",
@@ -592,7 +592,7 @@ func TestCreateTableOp_Execute(t *testing.T) {
 			},
 			env:          env,
 			wantErr:      true,
-			errorPattern: "unable to create base table for my_table: invalid json pointed by \\$\\.int: not an array",
+			errorPattern: "unable to create base table for my_table: invalid json pointed by \\$\\.int: invalid input: not an array",
 		},
 		{
 			name: "create table from json path: not an array of struct",
@@ -611,7 +611,7 @@ func TestCreateTableOp_Execute(t *testing.T) {
 			},
 			env:          env,
 			wantErr:      true,
-			errorPattern: "unable to create base table for my_table: invalid json pointed by \\$\\.array_float: not an array of JSON object",
+			errorPattern: "unable to create base table for my_table: invalid json pointed by \\$\\.array_float: invalid input: not an array of JSON object",
 		},
 		{
 			name: "create table from column definition using jsonPath pointing to 2 array with different length",

--- a/api/pkg/transformer/pipeline/create_table_op_test.go
+++ b/api/pkg/transformer/pipeline/create_table_op_test.go
@@ -611,7 +611,7 @@ func TestCreateTableOp_Execute(t *testing.T) {
 			},
 			env:          env,
 			wantErr:      true,
-			errorPattern: "unable to create base table for my_table: invalid json pointed by \\$\\.array_float: invalid input: not an array of JSON object",
+			errorPattern: "unable to create base table for my_table: invalid json pointed by \\$\\.array_float: invalid input: not an array of object",
 		},
 		{
 			name: "create table from column definition using jsonPath pointing to 2 array with different length",

--- a/api/pkg/transformer/pipeline/create_table_op_test.go
+++ b/api/pkg/transformer/pipeline/create_table_op_test.go
@@ -611,7 +611,7 @@ func TestCreateTableOp_Execute(t *testing.T) {
 			},
 			env:          env,
 			wantErr:      true,
-			errorPattern: "unable to create base table for my_table: invalid json pointed by \\$\\.array_float: invalid input: not an array of object",
+			errorPattern: "unable to create base table for my_table: invalid json pointed by \\$\\.array_float: invalid input: not an array of objects",
 		},
 		{
 			name: "create table from column definition using jsonPath pointing to 2 array with different length",

--- a/api/pkg/transformer/pipeline/json_output_op.go
+++ b/api/pkg/transformer/pipeline/json_output_op.go
@@ -127,6 +127,6 @@ func (j JsonOutputOp) createBaseJsonOutput(env *Environment, baseJson *spec.Base
 	case map[string]interface{}:
 		return types.JSONObject(v), nil
 	default:
-		return nil, mErrors.NewInvalidInputError("value in jsonpath must be object")
+		return nil, mErrors.NewInvalidInputError("value in jsonpath is not an object")
 	}
 }

--- a/api/pkg/transformer/pipeline/json_output_op.go
+++ b/api/pkg/transformer/pipeline/json_output_op.go
@@ -2,8 +2,8 @@ package pipeline
 
 import (
 	"context"
-	"errors"
 
+	mErrors "github.com/gojek/merlin/pkg/errors"
 	"github.com/gojek/merlin/pkg/transformer/spec"
 	"github.com/gojek/merlin/pkg/transformer/types"
 	"github.com/gojek/merlin/pkg/transformer/types/series"
@@ -127,6 +127,6 @@ func (j JsonOutputOp) createBaseJsonOutput(env *Environment, baseJson *spec.Base
 	case map[string]interface{}:
 		return types.JSONObject(v), nil
 	default:
-		return nil, errors.New("value in jsonpath must be object")
+		return nil, mErrors.NewInvalidInputError("value in jsonpath must be object")
 	}
 }

--- a/api/pkg/transformer/pipeline/json_output_op_test.go
+++ b/api/pkg/transformer/pipeline/json_output_op_test.go
@@ -155,7 +155,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("value in jsonpath must be object"),
+			err: errors.New("invalid input: value in jsonpath must be object"),
 		},
 		{
 			desc: "using base json only - failed when jsonpath value is literal",
@@ -182,7 +182,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("value in jsonpath must be object"),
+			err: errors.New("invalid input: value in jsonpath must be object"),
 		},
 		{
 			desc: "using base json - specifiying field",
@@ -637,7 +637,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("compiled jsonpath $.merchant_info not found"),
+			err: errors.New("invalid input: compiled jsonpath $.merchant_info not found"),
 		},
 		{
 			desc: "table has not been registered yet",
@@ -668,7 +668,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("table prediction_table is not declared"),
+			err: errors.New("invalid input: table prediction_table is not declared"),
 		},
 		{
 			desc: "table has been compiled, but not yet set the value",
@@ -702,7 +702,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("table prediction_table is not declared"),
+			err: errors.New("invalid input: table prediction_table is not declared"),
 		},
 		{
 			desc: "table has been compiled, but the value is not table",
@@ -737,7 +737,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("variable prediction_table is not a table"),
+			err: errors.New("invalid input: variable prediction_table is not a table"),
 		},
 		{
 			desc: "base table - jsonpath is not specified",
@@ -759,7 +759,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					BaseJson: &spec.BaseJson{},
 				},
 			},
-			err: errors.New("compiled jsonpath  not found"),
+			err: errors.New("invalid input: compiled jsonpath  not found"),
 		},
 		{
 			desc: "specifiying multiple fields using expressions which value is kind of table or series",

--- a/api/pkg/transformer/pipeline/json_output_op_test.go
+++ b/api/pkg/transformer/pipeline/json_output_op_test.go
@@ -637,7 +637,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("compiled jsonpath $.merchant_info not found"),
+			err: errors.New("compiled jsonpath '$.merchant_info' not found"),
 		},
 		{
 			desc: "table has not been registered yet",
@@ -668,7 +668,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("invalid input: table prediction_table is not declared"),
+			err: errors.New("invalid input: table 'prediction_table' is not declared"),
 		},
 		{
 			desc: "table has been compiled, but not yet set the value",
@@ -702,7 +702,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("invalid input: table prediction_table is not declared"),
+			err: errors.New("invalid input: table 'prediction_table' is not declared"),
 		},
 		{
 			desc: "table has been compiled, but the value is not table",
@@ -737,7 +737,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("invalid input: variable prediction_table is not a table"),
+			err: errors.New("invalid input: variable 'prediction_table' is not a table"),
 		},
 		{
 			desc: "base table - jsonpath is not specified",

--- a/api/pkg/transformer/pipeline/json_output_op_test.go
+++ b/api/pkg/transformer/pipeline/json_output_op_test.go
@@ -155,7 +155,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("invalid input: value in jsonpath must be object"),
+			err: errors.New("invalid input: value in jsonpath is not an object"),
 		},
 		{
 			desc: "using base json only - failed when jsonpath value is literal",
@@ -182,7 +182,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("invalid input: value in jsonpath must be object"),
+			err: errors.New("invalid input: value in jsonpath is not an object"),
 		},
 		{
 			desc: "using base json - specifiying field",

--- a/api/pkg/transformer/pipeline/json_output_op_test.go
+++ b/api/pkg/transformer/pipeline/json_output_op_test.go
@@ -637,7 +637,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("invalid input: compiled jsonpath $.merchant_info not found"),
+			err: errors.New("compiled jsonpath $.merchant_info not found"),
 		},
 		{
 			desc: "table has not been registered yet",
@@ -759,7 +759,7 @@ func TestJsonOutputOp_Execute(t *testing.T) {
 					BaseJson: &spec.BaseJson{},
 				},
 			},
-			err: errors.New("invalid input: compiled jsonpath  not found"),
+			err: errors.New("invalid input: jsonpath is not specified"),
 		},
 		{
 			desc: "specifiying multiple fields using expressions which value is kind of table or series",

--- a/api/pkg/transformer/pipeline/table_join_op.go
+++ b/api/pkg/transformer/pipeline/table_join_op.go
@@ -131,12 +131,12 @@ func getTable(env *Environment, tableName string) (*table.Table, error) {
 func getTableFromSymbolRegistry(sr symbol.Registry, tableName string) (*table.Table, error) {
 	tableRaw := sr[tableName]
 	if tableRaw == nil {
-		return nil, mErrors.NewInvalidInputErrorf("table %s is not declared", tableName)
+		return nil, mErrors.NewInvalidInputErrorf("table '%s' is not declared", tableName)
 	}
 
 	tableOut, ok := tableRaw.(*table.Table)
 	if !ok {
-		return nil, mErrors.NewInvalidInputErrorf("variable %s is not a table", tableName)
+		return nil, mErrors.NewInvalidInputErrorf("variable '%s' is not a table", tableName)
 	}
 	return tableOut, nil
 }
@@ -156,19 +156,19 @@ func validateJoinColumns(leftTable *table.Table, rightTable *table.Table, joinCo
 
 	if len(leftTableColumns) > 0 && len(rightTableColumns) > 0 {
 		if strings.Join(leftTableColumns, ", ") == strings.Join(rightTableColumns, ", ") {
-			return mErrors.NewInvalidInputErrorf("invalid join column: column %s does not exists in %s", strings.Join(leftTableColumns, ", "), "left table and right table")
+			return mErrors.NewInvalidInputErrorf("invalid join column: column %s does not exist in %s", strings.Join(leftTableColumns, ", "), "left table and right table")
 		}
 	}
 
 	var errMessages []string
 	if len(leftTableColumns) > 0 {
 		missingColumns := strings.Join(leftTableColumns, ", ")
-		errMessages = append(errMessages, fmt.Sprintf("column %s does not exists in %s", missingColumns, "left table"))
+		errMessages = append(errMessages, fmt.Sprintf("column %s does not exist in %s", missingColumns, "left table"))
 	}
 
 	if len(rightTableColumns) > 0 {
 		missingColumns := strings.Join(rightTableColumns, ", ")
-		errMessages = append(errMessages, fmt.Sprintf("column %s does not exists in %s", missingColumns, "right table"))
+		errMessages = append(errMessages, fmt.Sprintf("column %s does not exist in %s", missingColumns, "right table"))
 	}
 
 	if len(errMessages) > 0 {

--- a/api/pkg/transformer/pipeline/table_join_op.go
+++ b/api/pkg/transformer/pipeline/table_join_op.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
+	mErrors "github.com/gojek/merlin/pkg/errors"
 	"github.com/gojek/merlin/pkg/transformer/spec"
 	"github.com/gojek/merlin/pkg/transformer/symbol"
 	"github.com/gojek/merlin/pkg/transformer/types"
@@ -107,7 +108,7 @@ func (t TableJoinOp) Execute(ctx context.Context, environment *Environment) erro
 			return err
 		}
 	default:
-		return fmt.Errorf("unknown join method: %s", t.tableJoinSpec.How)
+		return mErrors.NewInvalidInputErrorf("unknown join method: %s", t.tableJoinSpec.How)
 	}
 
 	environment.SetSymbol(t.tableJoinSpec.OutputTable, resultTable)
@@ -130,12 +131,12 @@ func getTable(env *Environment, tableName string) (*table.Table, error) {
 func getTableFromSymbolRegistry(sr symbol.Registry, tableName string) (*table.Table, error) {
 	tableRaw := sr[tableName]
 	if tableRaw == nil {
-		return nil, fmt.Errorf("table %s is not declared", tableName)
+		return nil, mErrors.NewInvalidInputErrorf("table %s is not declared", tableName)
 	}
 
 	tableOut, ok := tableRaw.(*table.Table)
 	if !ok {
-		return nil, fmt.Errorf("variable %s is not a table", tableName)
+		return nil, mErrors.NewInvalidInputErrorf("variable %s is not a table", tableName)
 	}
 	return tableOut, nil
 }
@@ -155,7 +156,7 @@ func validateJoinColumns(leftTable *table.Table, rightTable *table.Table, joinCo
 
 	if len(leftTableColumns) > 0 && len(rightTableColumns) > 0 {
 		if strings.Join(leftTableColumns, ", ") == strings.Join(rightTableColumns, ", ") {
-			return fmt.Errorf("invalid join column: column %s does not exists in %s", strings.Join(leftTableColumns, ", "), "left table and right table")
+			return mErrors.NewInvalidInputErrorf("invalid join column: column %s does not exists in %s", strings.Join(leftTableColumns, ", "), "left table and right table")
 		}
 	}
 
@@ -171,7 +172,7 @@ func validateJoinColumns(leftTable *table.Table, rightTable *table.Table, joinCo
 	}
 
 	if len(errMessages) > 0 {
-		return fmt.Errorf("invalid join column: %s", strings.Join(errMessages, " and "))
+		return mErrors.NewInvalidInputErrorf("invalid join column: %s", strings.Join(errMessages, " and "))
 	}
 
 	return nil

--- a/api/pkg/transformer/pipeline/table_join_op_test.go
+++ b/api/pkg/transformer/pipeline/table_join_op_test.go
@@ -209,7 +209,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column order_id does not exists in left table"),
+			expError: errors.New("invalid input: invalid join column: column order_id does not exist in left table"),
 		},
 		{
 			name: "error: join column does not exist in right table -- join on one column (using deprecated onColumn field)",
@@ -222,7 +222,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column age does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column age does not exist in right table"),
 		},
 		{
 			name: "error: not a table -- join on one column (using deprecated onColumn field)",
@@ -235,7 +235,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: variable integer_var is not a table"),
+			expError: errors.New("invalid input: variable 'integer_var' is not a table"),
 		},
 		{
 			name: "error: table not found -- join on one column (using deprecated onColumn field)",
@@ -248,7 +248,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: table unknown_table is not declared"),
+			expError: errors.New("invalid input: table 'unknown_table' is not declared"),
 		},
 		{
 			name: "success: left join two table -- join on one column",
@@ -348,7 +348,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column order_id does not exists in left table"),
+			expError: errors.New("invalid input: invalid join column: column order_id does not exist in left table"),
 		},
 		{
 			name: "error: join column does not exist in right table -- join on one column",
@@ -361,7 +361,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column age does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column age does not exist in right table"),
 		},
 		{
 			name: "error: not a table -- join on one column",
@@ -374,7 +374,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: variable integer_var is not a table"),
+			expError: errors.New("invalid input: variable 'integer_var' is not a table"),
 		},
 		{
 			name: "error: table not found -- join on one column",
@@ -387,7 +387,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: table unknown_table is not declared"),
+			expError: errors.New("invalid input: table 'unknown_table' is not declared"),
 		},
 		{
 			name: "success: left join two table-- join on multiple columns",
@@ -484,7 +484,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column col_float does not exists in left table"),
+			expError: errors.New("invalid input: invalid join column: column col_float does not exist in left table"),
 		},
 		{
 			name: "error: join column does not exist in right table -- join on multiple columns",
@@ -497,7 +497,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column col_bool does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column col_bool does not exist in right table"),
 		},
 		{
 			name: "error: a join column does not exist in left table or right table -- join on multiple columns",
@@ -510,7 +510,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column col_float does not exists in left table and column col_bool does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column col_float does not exist in left table and column col_bool does not exist in right table"),
 		},
 		{
 			name: "error: join column does not exist in right table -- join on multiple columns",
@@ -523,7 +523,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column col_bool does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column col_bool does not exist in right table"),
 		},
 		{
 			name: "error: join column does not exist in both tables -- join on multiple columns",
@@ -536,7 +536,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column col_float32 does not exists in left table and right table"),
+			expError: errors.New("invalid input: invalid join column: column col_float32 does not exist in left table and right table"),
 		},
 		{
 			name: "error: join columns does not exist in both tables -- join on multiple columns",
@@ -549,7 +549,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column col_float32, col_float64 does not exists in left table and right table"),
+			expError: errors.New("invalid input: invalid join column: column col_float32, col_float64 does not exist in left table and right table"),
 		},
 		{
 			name: "error: multiple join columns does not exist in left table or right table -- join on multiple columns",
@@ -562,7 +562,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: invalid join column: column col_float, col_float32, col_float64 does not exists in left table and column col_bool, col_float32, col_float64 does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column col_float, col_float32, col_float64 does not exist in left table and column col_bool, col_float32, col_float64 does not exist in right table"),
 		},
 	}
 	for _, tt := range tests {

--- a/api/pkg/transformer/pipeline/table_join_op_test.go
+++ b/api/pkg/transformer/pipeline/table_join_op_test.go
@@ -209,7 +209,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column order_id does not exists in left table"),
+			expError: errors.New("invalid input: invalid join column: column order_id does not exists in left table"),
 		},
 		{
 			name: "error: join column does not exist in right table -- join on one column (using deprecated onColumn field)",
@@ -222,7 +222,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column age does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column age does not exists in right table"),
 		},
 		{
 			name: "error: not a table -- join on one column (using deprecated onColumn field)",
@@ -235,7 +235,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("variable integer_var is not a table"),
+			expError: errors.New("invalid input: variable integer_var is not a table"),
 		},
 		{
 			name: "error: table not found -- join on one column (using deprecated onColumn field)",
@@ -248,7 +248,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("table unknown_table is not declared"),
+			expError: errors.New("invalid input: table unknown_table is not declared"),
 		},
 		{
 			name: "success: left join two table -- join on one column",
@@ -348,7 +348,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column order_id does not exists in left table"),
+			expError: errors.New("invalid input: invalid join column: column order_id does not exists in left table"),
 		},
 		{
 			name: "error: join column does not exist in right table -- join on one column",
@@ -361,7 +361,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column age does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column age does not exists in right table"),
 		},
 		{
 			name: "error: not a table -- join on one column",
@@ -374,7 +374,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("variable integer_var is not a table"),
+			expError: errors.New("invalid input: variable integer_var is not a table"),
 		},
 		{
 			name: "error: table not found -- join on one column",
@@ -387,7 +387,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("table unknown_table is not declared"),
+			expError: errors.New("invalid input: table unknown_table is not declared"),
 		},
 		{
 			name: "success: left join two table-- join on multiple columns",
@@ -484,7 +484,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column col_float does not exists in left table"),
+			expError: errors.New("invalid input: invalid join column: column col_float does not exists in left table"),
 		},
 		{
 			name: "error: join column does not exist in right table -- join on multiple columns",
@@ -497,7 +497,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column col_bool does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column col_bool does not exists in right table"),
 		},
 		{
 			name: "error: a join column does not exist in left table or right table -- join on multiple columns",
@@ -510,7 +510,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column col_float does not exists in left table and column col_bool does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column col_float does not exists in left table and column col_bool does not exists in right table"),
 		},
 		{
 			name: "error: join column does not exist in right table -- join on multiple columns",
@@ -523,7 +523,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column col_bool does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column col_bool does not exists in right table"),
 		},
 		{
 			name: "error: join column does not exist in both tables -- join on multiple columns",
@@ -536,7 +536,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column col_float32 does not exists in left table and right table"),
+			expError: errors.New("invalid input: invalid join column: column col_float32 does not exists in left table and right table"),
 		},
 		{
 			name: "error: join columns does not exist in both tables -- join on multiple columns",
@@ -549,7 +549,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column col_float32, col_float64 does not exists in left table and right table"),
+			expError: errors.New("invalid input: invalid join column: column col_float32, col_float64 does not exists in left table and right table"),
 		},
 		{
 			name: "error: multiple join columns does not exist in left table or right table -- join on multiple columns",
@@ -562,7 +562,7 @@ func TestTableJoinOp_Execute(t *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid join column: column col_float, col_float32, col_float64 does not exists in left table and column col_bool, col_float32, col_float64 does not exists in right table"),
+			expError: errors.New("invalid input: invalid join column: column col_float, col_float32, col_float64 does not exists in left table and column col_bool, col_float32, col_float64 does not exists in right table"),
 		},
 	}
 	for _, tt := range tests {

--- a/api/pkg/transformer/pipeline/table_transform_op.go
+++ b/api/pkg/transformer/pipeline/table_transform_op.go
@@ -173,11 +173,11 @@ func (t TableTransformOp) Execute(context context.Context, env *Environment) err
 func getEncoder(env *Environment, encoderName string) (Encoder, error) {
 	encoderRaw := env.symbolRegistry[encoderName]
 	if encoderRaw == nil {
-		return nil, mErrors.NewInvalidInputErrorf("encoder %s is not declared", encoderName)
+		return nil, mErrors.NewInvalidInputErrorf("encoder '%s' is not declared", encoderName)
 	}
 	encodeImpl, ok := encoderRaw.(Encoder)
 	if !ok {
-		return nil, mErrors.NewInvalidInputErrorf("variable %s is not encoder", encoderName)
+		return nil, mErrors.NewInvalidInputErrorf("variable '%s' is not an encoder", encoderName)
 	}
 	return encodeImpl, nil
 }

--- a/api/pkg/transformer/pipeline/table_transform_op.go
+++ b/api/pkg/transformer/pipeline/table_transform_op.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	mErrors "github.com/gojek/merlin/pkg/errors"
 	"github.com/gojek/merlin/pkg/transformer/spec"
 	"github.com/gojek/merlin/pkg/transformer/types"
 	"github.com/gojek/merlin/pkg/transformer/types/scaler"
@@ -172,11 +173,11 @@ func (t TableTransformOp) Execute(context context.Context, env *Environment) err
 func getEncoder(env *Environment, encoderName string) (Encoder, error) {
 	encoderRaw := env.symbolRegistry[encoderName]
 	if encoderRaw == nil {
-		return nil, fmt.Errorf("encoder %s is not declared", encoderName)
+		return nil, mErrors.NewInvalidInputErrorf("encoder %s is not declared", encoderName)
 	}
 	encodeImpl, ok := encoderRaw.(Encoder)
 	if !ok {
-		return nil, fmt.Errorf("variable %s is not encoder", encoderName)
+		return nil, mErrors.NewInvalidInputErrorf("variable %s is not encoder", encoderName)
 	}
 	return encodeImpl, nil
 }

--- a/api/pkg/transformer/pipeline/table_transform_op_test.go
+++ b/api/pkg/transformer/pipeline/table_transform_op_test.go
@@ -580,7 +580,7 @@ func TestTableTransformOp_Execute(t1 *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("variable integer_var is not a table"),
+			expError: errors.New("invalid input: variable integer_var is not a table"),
 		},
 		{
 			name: "error: input variable is not found",
@@ -600,7 +600,7 @@ func TestTableTransformOp_Execute(t1 *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("table unknown_table is not declared"),
+			expError: errors.New("invalid input: table unknown_table is not declared"),
 		},
 		{
 			name: "error: scale existing column in table is not numeric ",
@@ -625,7 +625,7 @@ func TestTableTransformOp_Execute(t1 *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: fmt.Errorf("this series type is not numeric but string"),
+			expError: fmt.Errorf("invalid input: this series type is not numeric but string"),
 		},
 		{
 			name: "error: encode columns, referred encoder is not exist",
@@ -645,7 +645,7 @@ func TestTableTransformOp_Execute(t1 *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: fmt.Errorf("encoder notExistEncoder is not declared"),
+			expError: fmt.Errorf("invalid input: encoder notExistEncoder is not declared"),
 		},
 		{
 			name: "error: encode columns, referred encoder is not encoder type",
@@ -665,7 +665,7 @@ func TestTableTransformOp_Execute(t1 *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: fmt.Errorf("variable existing_table is not encoder"),
+			expError: fmt.Errorf("invalid input: variable existing_table is not encoder"),
 		},
 	}
 	for _, tt := range tests {

--- a/api/pkg/transformer/pipeline/table_transform_op_test.go
+++ b/api/pkg/transformer/pipeline/table_transform_op_test.go
@@ -580,7 +580,7 @@ func TestTableTransformOp_Execute(t1 *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: variable integer_var is not a table"),
+			expError: errors.New("invalid input: variable 'integer_var' is not a table"),
 		},
 		{
 			name: "error: input variable is not found",
@@ -600,7 +600,7 @@ func TestTableTransformOp_Execute(t1 *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: errors.New("invalid input: table unknown_table is not declared"),
+			expError: errors.New("invalid input: table 'unknown_table' is not declared"),
 		},
 		{
 			name: "error: scale existing column in table is not numeric ",
@@ -645,7 +645,7 @@ func TestTableTransformOp_Execute(t1 *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: fmt.Errorf("invalid input: encoder notExistEncoder is not declared"),
+			expError: fmt.Errorf("invalid input: encoder 'notExistEncoder' is not declared"),
 		},
 		{
 			name: "error: encode columns, referred encoder is not encoder type",
@@ -665,7 +665,7 @@ func TestTableTransformOp_Execute(t1 *testing.T) {
 			},
 			env:      env,
 			wantErr:  true,
-			expError: fmt.Errorf("invalid input: variable existing_table is not encoder"),
+			expError: fmt.Errorf("invalid input: variable 'existing_table' is not an encoder"),
 		},
 	}
 	for _, tt := range tests {

--- a/api/pkg/transformer/pipeline/upi_autoloading_op.go
+++ b/api/pkg/transformer/pipeline/upi_autoloading_op.go
@@ -60,7 +60,7 @@ func validateRequest(payload *types.UPIPredictionRequest) error {
 
 	for _, variable := range payload.TransformerInput.Variables {
 		if variable.Name == "" {
-			return mErrors.NewInvalidInputError("variable name must be specified")
+			return mErrors.NewInvalidInputError("variable name is not specified")
 		}
 	}
 	return nil
@@ -71,11 +71,11 @@ func validateUPITable(tbl *upiv1.Table) error {
 	// since row_id will be automated created from row entry
 	// if table doesn't have name we will throw error
 	if tbl.Name == "" {
-		return mErrors.NewInvalidInputError("table name must be specified")
+		return mErrors.NewInvalidInputError("table name is not specified")
 	}
 	for _, col := range tbl.Columns {
 		if col.Name == table.RowIDColumn {
-			return mErrors.NewInvalidInputError("row_id column is reserved, user is not allowed to define explicitly row_id column")
+			return mErrors.NewInvalidInputError("table contains a reserved column name row_id")
 		}
 	}
 	return nil

--- a/api/pkg/transformer/pipeline/upi_autoloading_op.go
+++ b/api/pkg/transformer/pipeline/upi_autoloading_op.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	upiv1 "github.com/caraml-dev/universal-prediction-interface/gen/go/grpc/caraml/upi/v1"
+	mErrors "github.com/gojek/merlin/pkg/errors"
 	"github.com/gojek/merlin/pkg/transformer/types"
 	"github.com/gojek/merlin/pkg/transformer/types/table"
 )
@@ -59,7 +60,7 @@ func validateRequest(payload *types.UPIPredictionRequest) error {
 
 	for _, variable := range payload.TransformerInput.Variables {
 		if variable.Name == "" {
-			return fmt.Errorf("variable name must be specified")
+			return mErrors.NewInvalidInputError("variable name must be specified")
 		}
 	}
 	return nil
@@ -70,11 +71,11 @@ func validateUPITable(tbl *upiv1.Table) error {
 	// since row_id will be automated created from row entry
 	// if table doesn't have name we will throw error
 	if tbl.Name == "" {
-		return fmt.Errorf("table name must be specified")
+		return mErrors.NewInvalidInputError("table name must be specified")
 	}
 	for _, col := range tbl.Columns {
 		if col.Name == table.RowIDColumn {
-			return fmt.Errorf("row_id column is reserved, user is not allowed to define explicitly row_id column")
+			return mErrors.NewInvalidInputError("row_id column is reserved, user is not allowed to define explicitly row_id column")
 		}
 	}
 	return nil
@@ -84,7 +85,7 @@ func (ua *UPIAutoloadingOp) autoLoadingPreprocessInput(ctx context.Context, env 
 	requestPayload := env.symbolRegistry.RawRequest()
 	upiRequestPayload, valid := requestPayload.(*types.UPIPredictionRequest)
 	if !valid {
-		return fmt.Errorf("raw request is not valid")
+		return mErrors.NewInvalidInputError("raw request is not valid")
 	}
 
 	if err := validateRequest(upiRequestPayload); err != nil {
@@ -134,7 +135,7 @@ func generateVariableFromRequest(requestPayload *types.UPIPredictionRequest, env
 		case upiv1.Type_TYPE_STRING:
 			variables[variable.Name] = variable.StringValue
 		default:
-			return nil, fmt.Errorf("unknown type %T", variable)
+			return nil, mErrors.NewInvalidInputErrorf("unknown type %T", variable)
 		}
 	}
 	return variables, nil

--- a/api/pkg/transformer/pipeline/upi_autoloading_op_test.go
+++ b/api/pkg/transformer/pipeline/upi_autoloading_op_test.go
@@ -506,7 +506,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("invalid input: row_id column is reserved, user is not allowed to define explicitly row_id column"),
+			expectedErr: fmt.Errorf("invalid input: table contains a reserved column name row_id"),
 		},
 		{
 			name:         "got error; prediction_table name is specified",
@@ -639,7 +639,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("invalid input: table name must be specified"),
+			expectedErr: fmt.Errorf("invalid input: table name is not specified"),
 		},
 		{
 			name:         "got error; prediction_table name is specified",
@@ -772,7 +772,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("invalid input: variable name must be specified"),
+			expectedErr: fmt.Errorf("invalid input: variable name is not specified"),
 		},
 		{
 			name:         "got error; table in transformer_input contains row_id",
@@ -915,7 +915,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("invalid input: row_id column is reserved, user is not allowed to define explicitly row_id column"),
+			expectedErr: fmt.Errorf("invalid input: table contains a reserved column name row_id"),
 		},
 		{
 			name:         "got error; table in response contains row_id",
@@ -1001,7 +1001,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("invalid input: row_id column is reserved, user is not allowed to define explicitly row_id column"),
+			expectedErr: fmt.Errorf("invalid input: table contains a reserved column name row_id"),
 		},
 		{
 			name:         "got error; table in response doesn't have name",
@@ -1068,7 +1068,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("invalid input: table name must be specified"),
+			expectedErr: fmt.Errorf("invalid input: table name is not specified"),
 		},
 		{
 			name:         "got error; number of columns is not the same with number of values in each row",

--- a/api/pkg/transformer/pipeline/upi_autoloading_op_test.go
+++ b/api/pkg/transformer/pipeline/upi_autoloading_op_test.go
@@ -506,7 +506,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("row_id column is reserved, user is not allowed to define explicitly row_id column"),
+			expectedErr: fmt.Errorf("invalid input: row_id column is reserved, user is not allowed to define explicitly row_id column"),
 		},
 		{
 			name:         "got error; prediction_table name is specified",
@@ -639,7 +639,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("table name must be specified"),
+			expectedErr: fmt.Errorf("invalid input: table name must be specified"),
 		},
 		{
 			name:         "got error; prediction_table name is specified",
@@ -772,7 +772,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("variable name must be specified"),
+			expectedErr: fmt.Errorf("invalid input: variable name must be specified"),
 		},
 		{
 			name:         "got error; table in transformer_input contains row_id",
@@ -915,7 +915,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("row_id column is reserved, user is not allowed to define explicitly row_id column"),
+			expectedErr: fmt.Errorf("invalid input: row_id column is reserved, user is not allowed to define explicitly row_id column"),
 		},
 		{
 			name:         "got error; table in response contains row_id",
@@ -1001,7 +1001,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("row_id column is reserved, user is not allowed to define explicitly row_id column"),
+			expectedErr: fmt.Errorf("invalid input: row_id column is reserved, user is not allowed to define explicitly row_id column"),
 		},
 		{
 			name:         "got error; table in response doesn't have name",
@@ -1068,7 +1068,7 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 				},
 				logger: logger,
 			},
-			expectedErr: fmt.Errorf("table name must be specified"),
+			expectedErr: fmt.Errorf("invalid input: table name must be specified"),
 		},
 		{
 			name:         "got error; number of columns is not the same with number of values in each row",
@@ -1163,8 +1163,8 @@ func TestUPIAutoloadingOp_Execute(t *testing.T) {
 			tt.env.symbolRegistry.SetModelResponse((*types.UPIPredictionResponse)(tt.modelResponse))
 
 			err := ua.Execute(context.Background(), tt.env)
-			require.Equal(t, tt.expectedErr, err)
 			if tt.expectedErr != nil {
+				require.EqualError(t, tt.expectedErr, err.Error())
 				return
 			}
 			for varName, varValue := range tt.expVariables {

--- a/api/pkg/transformer/pipeline/upi_postprocess_output_op_test.go
+++ b/api/pkg/transformer/pipeline/upi_postprocess_output_op_test.go
@@ -255,7 +255,7 @@ func TestUPIPostprocessOutputOp_Execute(t *testing.T) {
 				PredictionResultTableName: "driver_table_not_exist",
 			},
 			env:    env,
-			expErr: fmt.Errorf("invalid input: table driver_table_not_exist is not declared"),
+			expErr: fmt.Errorf("invalid input: table 'driver_table_not_exist' is not declared"),
 		},
 	}
 	for _, tt := range tests {

--- a/api/pkg/transformer/pipeline/upi_postprocess_output_op_test.go
+++ b/api/pkg/transformer/pipeline/upi_postprocess_output_op_test.go
@@ -255,7 +255,7 @@ func TestUPIPostprocessOutputOp_Execute(t *testing.T) {
 				PredictionResultTableName: "driver_table_not_exist",
 			},
 			env:    env,
-			expErr: fmt.Errorf("table driver_table_not_exist is not declared"),
+			expErr: fmt.Errorf("invalid input: table driver_table_not_exist is not declared"),
 		},
 	}
 	for _, tt := range tests {
@@ -264,8 +264,8 @@ func TestUPIPostprocessOutputOp_Execute(t *testing.T) {
 				outputSpec: tt.outputSpec,
 			}
 			err := up.Execute(context.Background(), tt.env)
-			assert.Equal(t, tt.expErr, err)
 			if tt.expErr != nil {
+				assert.EqualError(t, tt.expErr, err.Error())
 				return
 			}
 			got := tt.env.Output()

--- a/api/pkg/transformer/pipeline/upi_preprocess_output_op_test.go
+++ b/api/pkg/transformer/pipeline/upi_preprocess_output_op_test.go
@@ -651,7 +651,7 @@ func TestUPIPreprocessOutputOp_Execute(t *testing.T) {
 				PredictionTableName: "prediction_table_not_exist",
 			},
 			env:    env,
-			expErr: fmt.Errorf("table prediction_table_not_exist is not declared"),
+			expErr: fmt.Errorf("invalid input: table prediction_table_not_exist is not declared"),
 		},
 	}
 	for _, tt := range tests {
@@ -660,8 +660,9 @@ func TestUPIPreprocessOutputOp_Execute(t *testing.T) {
 				outputSpec: tt.outputSpec,
 			}
 			err := up.Execute(context.Background(), tt.env)
-			assert.Equal(t, tt.expErr, err)
+
 			if tt.expErr != nil {
+				assert.EqualError(t, tt.expErr, err.Error())
 				return
 			}
 			got := tt.env.Output()

--- a/api/pkg/transformer/pipeline/upi_preprocess_output_op_test.go
+++ b/api/pkg/transformer/pipeline/upi_preprocess_output_op_test.go
@@ -651,7 +651,7 @@ func TestUPIPreprocessOutputOp_Execute(t *testing.T) {
 				PredictionTableName: "prediction_table_not_exist",
 			},
 			env:    env,
-			expErr: fmt.Errorf("invalid input: table prediction_table_not_exist is not declared"),
+			expErr: fmt.Errorf("invalid input: table 'prediction_table_not_exist' is not declared"),
 		},
 	}
 	for _, tt := range tests {

--- a/api/pkg/transformer/pipeline/util.go
+++ b/api/pkg/transformer/pipeline/util.go
@@ -16,7 +16,7 @@ func evalJSONPath(env *Environment, jsonPath string) (interface{}, error) {
 	}
 	c := env.CompiledJSONPath(jsonPath)
 	if c == nil {
-		return nil, fmt.Errorf("compiled jsonpath %s not found", jsonPath)
+		return nil, fmt.Errorf("compiled jsonpath '%s' not found", jsonPath)
 
 	}
 
@@ -51,7 +51,7 @@ func seriesFromExpression(env *Environment, expression string) (*series.Series, 
 		return nil, err
 	}
 	if val == nil {
-		return nil, mErrors.NewInvalidInputErrorf("series is empty due to expression %s returning nil", expression)
+		return nil, mErrors.NewInvalidInputErrorf("series is empty due to expression '%s' returning nil", expression)
 	}
 	return series.NewInferType(val, "")
 }
@@ -81,7 +81,7 @@ func getVal(env *Environment, expression string) (interface{}, error) {
 	}
 	cplExpr := env.CompiledExpression(expression)
 	if cplExpr == nil {
-		return nil, fmt.Errorf("compiled expression %s not found", expression)
+		return nil, fmt.Errorf("compiled expression '%s' not found", expression)
 	}
 
 	val, err := expr.Run(env.CompiledExpression(expression), env.SymbolRegistry())

--- a/api/pkg/transformer/pipeline/util.go
+++ b/api/pkg/transformer/pipeline/util.go
@@ -1,6 +1,8 @@
 package pipeline
 
 import (
+	"fmt"
+
 	"github.com/antonmedv/expr"
 
 	mErrors "github.com/gojek/merlin/pkg/errors"
@@ -9,14 +11,18 @@ import (
 )
 
 func evalJSONPath(env *Environment, jsonPath string) (interface{}, error) {
+	if jsonPath == "" {
+		return nil, mErrors.NewInvalidInputError("jsonpath is not specified")
+	}
 	c := env.CompiledJSONPath(jsonPath)
 	if c == nil {
-		return nil, mErrors.NewInvalidInputErrorf("compiled jsonpath %s not found", jsonPath)
+		return nil, fmt.Errorf("compiled jsonpath %s not found", jsonPath)
+
 	}
 
 	val, err := c.LookupFromContainer(env.PayloadContainer())
 	if err != nil {
-		return nil, err
+		return nil, mErrors.NewInvalidInputErrorf(err.Error())
 	}
 	return val, nil
 }
@@ -70,9 +76,12 @@ func subsetSeriesFromExpression(env *Environment, expression string, subsetIdx *
 }
 
 func getVal(env *Environment, expression string) (interface{}, error) {
+	if expression == "" {
+		return nil, mErrors.NewInvalidInputError("expression is not specified")
+	}
 	cplExpr := env.CompiledExpression(expression)
 	if cplExpr == nil {
-		return nil, mErrors.NewInvalidInputErrorf("compiled expression %s not found", expression)
+		return nil, fmt.Errorf("compiled expression %s not found", expression)
 	}
 
 	val, err := expr.Run(env.CompiledExpression(expression), env.SymbolRegistry())

--- a/api/pkg/transformer/pipeline/util.go
+++ b/api/pkg/transformer/pipeline/util.go
@@ -16,7 +16,7 @@ func evalJSONPath(env *Environment, jsonPath string) (interface{}, error) {
 
 	val, err := c.LookupFromContainer(env.PayloadContainer())
 	if err != nil {
-		return nil, mErrors.NewInvalidInputError(err.Error())
+		return nil, err
 	}
 	return val, nil
 }
@@ -34,7 +34,7 @@ func evalExpression(env *Environment, expression string) (interface{}, error) {
 	}
 
 	if err != nil {
-		return nil, mErrors.NewInvalidInputError(err.Error())
+		return nil, err
 	}
 	return val, nil
 }

--- a/api/pkg/transformer/server/grpc/server_test.go
+++ b/api/pkg/transformer/server/grpc/server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/afex/hystrix-go/hystrix"
 	upiv1 "github.com/caraml-dev/universal-prediction-interface/gen/go/grpc/caraml/upi/v1"
 	feastSdk "github.com/feast-dev/feast/sdk/go"
 	"github.com/feast-dev/feast/sdk/go/protos/feast/serving"
@@ -622,6 +623,7 @@ func TestUPIServer_PredictValues(t *testing.T) {
 		request         *feastSdk.OnlineFeaturesRequest
 		expectedRequest *feastSdk.OnlineFeaturesRequest
 		response        *feastSdk.OnlineFeaturesResponse
+		err             error
 	}
 	tests := []struct {
 		name             string
@@ -630,6 +632,7 @@ func TestUPIServer_PredictValues(t *testing.T) {
 		request          *upiv1.PredictValuesRequest
 		preprocessOutput *upiv1.PredictValuesRequest
 		modelOutput      *upiv1.PredictValuesResponse
+		modelOutputErr   error
 		want             *upiv1.PredictValuesResponse
 		expectedErr      error
 	}{
@@ -1453,6 +1456,774 @@ func TestUPIServer_PredictValues(t *testing.T) {
 			},
 		},
 		{
+			name:         "table_transformations; model prediction timeout",
+			specYamlPath: "../../pipeline/testdata/upi/valid_table_transformer_preprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "transformed_driver_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "name",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+						{
+							Name: "rank",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "rating",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "vehicle",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "previous_vehicle",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "row2",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1111,
+								},
+								{
+									StringValue: "driver-2",
+								},
+								{
+									DoubleValue: 2.5,
+								},
+								{
+									DoubleValue: 0.5,
+								},
+								{
+									IntegerValue: 2,
+								},
+								{
+									IntegerValue: 3,
+								},
+							},
+						},
+						{
+							RowId: "row1",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1111,
+								},
+								{
+									StringValue: "driver-1",
+								},
+								{
+									DoubleValue: -2.5,
+								},
+								{
+									DoubleValue: 0.75,
+								},
+								{
+									IntegerValue: 0,
+								},
+								{
+									IntegerValue: 1,
+								},
+							},
+						},
+					},
+				},
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{},
+				},
+			},
+			modelOutputErr: status.Error(codes.DeadlineExceeded, "timeout"),
+			expectedErr:    status.Error(codes.DeadlineExceeded, "predict err: rpc error: code = DeadlineExceeded desc = timeout"),
+		},
+		{
+			name:         "table_transformations; model prediction timeout from hystrix",
+			specYamlPath: "../../pipeline/testdata/upi/valid_table_transformer_preprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "transformed_driver_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "name",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+						{
+							Name: "rank",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "rating",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "vehicle",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "previous_vehicle",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "row2",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1111,
+								},
+								{
+									StringValue: "driver-2",
+								},
+								{
+									DoubleValue: 2.5,
+								},
+								{
+									DoubleValue: 0.5,
+								},
+								{
+									IntegerValue: 2,
+								},
+								{
+									IntegerValue: 3,
+								},
+							},
+						},
+						{
+							RowId: "row1",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1111,
+								},
+								{
+									StringValue: "driver-1",
+								},
+								{
+									DoubleValue: -2.5,
+								},
+								{
+									DoubleValue: 0.75,
+								},
+								{
+									IntegerValue: 0,
+								},
+								{
+									IntegerValue: 1,
+								},
+							},
+						},
+					},
+				},
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{},
+				},
+			},
+			modelOutputErr: hystrix.ErrTimeout,
+			expectedErr:    status.Error(codes.DeadlineExceeded, "predict err: deadline exceeded: hystrix: timeout"),
+		},
+		{
+			name:         "table_transformations; errors table is not defined in request",
+			specYamlPath: "../../pipeline/testdata/upi/valid_table_transformer_preprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "random_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			expectedErr: status.Error(codes.InvalidArgument, "preprocess err: error executing preprocess operation: *pipeline.TableTransformOp: invalid input: table driver_table is not declared"),
+		},
+		{
+			name:         "table_transformations; one of value for cyclical encoder is nil (test_time column)",
+			specYamlPath: "../../pipeline/testdata/upi/valid_table_transformer_preprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											IsNull: true,
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IsNull: true,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			expectedErr: status.Error(codes.InvalidArgument, "preprocess err: error executing preprocess operation: *pipeline.TableTransformOp: invalid input: there is missing value on column test_time, cyclical encoding fails"),
+		},
+		{
 			name:         "table_transformations with feast",
 			specYamlPath: "../../pipeline/testdata/upi/valid_feast_preprocess.yaml",
 			mockFeasts: []mockFeast{
@@ -1741,13 +2512,305 @@ func TestUPIServer_PredictValues(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:         "table_transformations with feast; timeout calling feast",
+			specYamlPath: "../../pipeline/testdata/upi/valid_feast_preprocess.yaml",
+			mockFeasts: []mockFeast{
+				{
+					request: &feastSdk.OnlineFeaturesRequest{
+						Project: "default", // used as identifier for mocking. must match config
+					},
+					err: hystrix.ErrTimeout,
+				},
+			},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "result_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "rank",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "driver_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "driver_feature_1",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "driver_feature_2",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 0,
+								},
+								{
+									IntegerValue: 1,
+								},
+								{
+									IntegerValue: 1111,
+								},
+								{
+									DoubleValue: 1111,
+								},
+								{
+									DoubleValue: 2222,
+								},
+							},
+						},
+						{
+							RowId: "",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1,
+								},
+								{
+									IntegerValue: 2,
+								},
+								{
+									IntegerValue: 1111,
+								},
+								{
+									DoubleValue: 3333,
+								},
+								{
+									DoubleValue: 4444,
+								},
+							},
+						},
+					},
+				},
+				TransformerInput: &upiv1.TransformerInput{
+					Tables:    []*upiv1.Table{},
+					Variables: []*upiv1.Variable{},
+				},
+			},
+			expectedErr: status.Error(codes.DeadlineExceeded, "preprocess err: error executing preprocess operation: *pipeline.FeastOp: deadline exceeded: hystrix: timeout"),
+		},
+		{
+			name:         "table_transformations with feast; timeout from server when calling feast",
+			specYamlPath: "../../pipeline/testdata/upi/valid_feast_preprocess.yaml",
+			mockFeasts: []mockFeast{
+				{
+					request: &feastSdk.OnlineFeaturesRequest{
+						Project: "default", // used as identifier for mocking. must match config
+					},
+					err: status.Error(codes.DeadlineExceeded, "feast timeout"),
+				},
+			},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "result_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "rank",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "driver_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "driver_feature_1",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "driver_feature_2",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 0,
+								},
+								{
+									IntegerValue: 1,
+								},
+								{
+									IntegerValue: 1111,
+								},
+								{
+									DoubleValue: 1111,
+								},
+								{
+									DoubleValue: 2222,
+								},
+							},
+						},
+						{
+							RowId: "",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1,
+								},
+								{
+									IntegerValue: 2,
+								},
+								{
+									IntegerValue: 1111,
+								},
+								{
+									DoubleValue: 3333,
+								},
+								{
+									DoubleValue: 4444,
+								},
+							},
+						},
+					},
+				},
+				TransformerInput: &upiv1.TransformerInput{
+					Tables:    []*upiv1.Table{},
+					Variables: []*upiv1.Variable{},
+				},
+			},
+			expectedErr: status.Error(codes.DeadlineExceeded, "preprocess err: error executing preprocess operation: *pipeline.FeastOp: deadline exceeded: feast timeout"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clientMock := &mocks.UniversalPredictionServiceClient{}
 			clientMock.On("PredictValues", mock.Anything, mock.MatchedBy(func(req *upiv1.PredictValuesRequest) bool {
 				return proto.Equal(tt.preprocessOutput, req)
-			})).Return(tt.modelOutput, nil)
+			})).Return(tt.modelOutput, tt.modelOutputErr)
 			mockFeast := &feastMocks.Client{}
 			feastClients := feast.Clients{}
 			feastClients[spec.ServingSource_BIGTABLE] = mockFeast
@@ -1769,7 +2832,7 @@ func TestUPIServer_PredictValues(t *testing.T) {
 						assert.Equal(t, expectedRequest.Features, req.Features)
 					}
 					return req.Project == project
-				})).Return(m.response, nil)
+				})).Return(m.response, m.err)
 			}
 			opts := &config.Options{
 				ModelGRPCHystrixCommandName: "grpcHandler",

--- a/api/pkg/transformer/server/grpc/server_test.go
+++ b/api/pkg/transformer/server/grpc/server_test.go
@@ -2115,7 +2115,7 @@ func TestUPIServer_PredictValues(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: status.Error(codes.InvalidArgument, "preprocess err: error executing preprocess operation: *pipeline.TableTransformOp: invalid input: table driver_table is not declared"),
+			expectedErr: status.Error(codes.InvalidArgument, "preprocess err: error executing preprocess operation: *pipeline.TableTransformOp: invalid input: table 'driver_table' is not declared"),
 		},
 		{
 			name:         "table_transformations; one of value for cyclical encoder is nil (test_time column)",

--- a/api/pkg/transformer/server/rest/server.go
+++ b/api/pkg/transformer/server/rest/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 
+	mErrors "github.com/gojek/merlin/pkg/errors"
 	hystrixpkg "github.com/gojek/merlin/pkg/hystrix"
 	"github.com/gojek/merlin/pkg/transformer/pipeline"
 	"github.com/gojek/merlin/pkg/transformer/server/config"
@@ -135,7 +136,7 @@ func (s *HTTPServer) PredictHandler(w http.ResponseWriter, r *http.Request) {
 	preprocessOutput, err := s.preprocess(ctx, requestBody, r.Header)
 	if err != nil {
 		s.logger.Error("preprocess error", zap.Error(err))
-		response.NewError(http.StatusInternalServerError, errors.Wrapf(err, "preprocessing error")).Write(w)
+		response.NewError(responseCodeFromError(err), errors.Wrapf(err, "preprocessing error")).Write(w)
 		return
 	}
 	s.logger.Debug("preprocess response", zap.ByteString("preprocess_response", preprocessOutput))
@@ -143,7 +144,7 @@ func (s *HTTPServer) PredictHandler(w http.ResponseWriter, r *http.Request) {
 	resp, err := s.predict(ctx, r, preprocessOutput)
 	if err != nil {
 		s.logger.Error("predict error", zap.Error(err))
-		response.NewError(http.StatusInternalServerError, errors.Wrapf(err, "prediction error")).Write(w)
+		response.NewError(responseCodeFromError(err), errors.Wrapf(err, "prediction error")).Write(w)
 		return
 	}
 
@@ -152,7 +153,7 @@ func (s *HTTPServer) PredictHandler(w http.ResponseWriter, r *http.Request) {
 	modelResponseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		s.logger.Error("error reading model response", zap.Error(err))
-		response.NewError(http.StatusInternalServerError, err).Write(w)
+		response.NewError(responseCodeFromError(err), err).Write(w)
 		return
 	}
 	s.logger.Debug("predict response", zap.ByteString("predict_response", modelResponseBody))
@@ -160,7 +161,7 @@ func (s *HTTPServer) PredictHandler(w http.ResponseWriter, r *http.Request) {
 	postprocessOutput, err := s.postprocess(ctx, types.BytePayload(modelResponseBody), resp.Header)
 	if err != nil {
 		s.logger.Error("postprocess error", zap.Error(err))
-		response.NewError(http.StatusInternalServerError, errors.Wrapf(err, "postprocessing error")).Write(w)
+		response.NewError(responseCodeFromError(err), errors.Wrapf(err, "postprocessing error")).Write(w)
 		return
 	}
 	s.logger.Debug("postprocess response", zap.ByteString("postprocess_response", postprocessOutput))
@@ -172,6 +173,13 @@ func (s *HTTPServer) PredictHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Error("failed writing postprocess response", zap.Error(err))
 	}
+}
+
+func responseCodeFromError(err error) int {
+	if errors.Is(err, mErrors.InvalidInputError) {
+		return http.StatusUnprocessableEntity
+	}
+	return http.StatusInternalServerError
 }
 
 func (s *HTTPServer) preprocess(ctx context.Context, request []byte, requestHeader http.Header) ([]byte, error) {

--- a/api/pkg/transformer/server/rest/server.go
+++ b/api/pkg/transformer/server/rest/server.go
@@ -177,7 +177,7 @@ func (s *HTTPServer) PredictHandler(w http.ResponseWriter, r *http.Request) {
 
 func responseCodeFromError(err error) int {
 	if errors.Is(err, mErrors.InvalidInputError) {
-		return http.StatusUnprocessableEntity
+		return http.StatusBadRequest
 	}
 	return http.StatusInternalServerError
 }

--- a/api/pkg/transformer/server/rest/server_test.go
+++ b/api/pkg/transformer/server/rest/server_test.go
@@ -311,10 +311,10 @@ func TestServer_PredictHandler_StandardTransformer(t *testing.T) {
 			expTransformedResponse: response{
 				headers: map[string]string{
 					"Content-Type":   "application/json",
-					"Content-Length": "189",
+					"Content-Length": "174",
 				},
-				body:       []byte(`{"code":422,"message":"preprocessing error: error executing preprocess operation: *pipeline.CreateTableOp: unable to create base table for entity_table: invalid input: object is not Slice"}`),
-				statusCode: 422,
+				body:       []byte(`{"code":500,"message":"preprocessing error: error executing preprocess operation: *pipeline.CreateTableOp: unable to create base table for entity_table: object is not Slice"}`),
+				statusCode: 500,
 			},
 		},
 		{
@@ -396,8 +396,8 @@ func TestServer_PredictHandler_StandardTransformer(t *testing.T) {
 					"Content-Type":   "application/json",
 					"Content-Length": "194",
 				},
-				body:       []byte(`{"code":422,"message":"preprocessing error: error executing preprocess operation: *pipeline.TableTransformOp: invalid input: there is missing value on column test_time, cyclical encoding fails"}`),
-				statusCode: 422,
+				body:       []byte(`{"code":400,"message":"preprocessing error: error executing preprocess operation: *pipeline.TableTransformOp: invalid input: there is missing value on column test_time, cyclical encoding fails"}`),
+				statusCode: 400,
 			},
 		},
 		{

--- a/api/pkg/transformer/server/rest/server_test.go
+++ b/api/pkg/transformer/server/rest/server_test.go
@@ -311,10 +311,10 @@ func TestServer_PredictHandler_StandardTransformer(t *testing.T) {
 			expTransformedResponse: response{
 				headers: map[string]string{
 					"Content-Type":   "application/json",
-					"Content-Length": "174",
+					"Content-Length": "189",
 				},
-				body:       []byte(`{"code":500,"message":"preprocessing error: error executing preprocess operation: *pipeline.CreateTableOp: unable to create base table for entity_table: object is not Slice"}`),
-				statusCode: 500,
+				body:       []byte(`{"code":400,"message":"preprocessing error: error executing preprocess operation: *pipeline.CreateTableOp: unable to create base table for entity_table: invalid input: object is not Slice"}`),
+				statusCode: 400,
 			},
 		},
 		{

--- a/api/pkg/transformer/server/rest/server_test.go
+++ b/api/pkg/transformer/server/rest/server_test.go
@@ -284,6 +284,40 @@ func TestServer_PredictHandler_StandardTransformer(t *testing.T) {
 			},
 		},
 		{
+			name:         "simple preprocess; failed due to entities supplied is not an array",
+			specYamlPath: "../../pipeline/testdata/valid_simple_preprocess_child.yaml",
+			mockFeasts:   []mockFeast{},
+			rawRequest: request{
+				headers: map[string]string{
+					"Content-Type": "application/json",
+				},
+				body: []byte(`{"entities" : {"id": 1,"name": "entity-1"}}`),
+			},
+			expTransformedRequest: request{
+				headers: map[string]string{
+					"Content-Type": "application/json",
+				},
+				body: []byte(`{"instances": {"columns": ["id", "name"], "data":[[1, "entity-1"],[2, "entity-2"]]},
+								"tablefile": {"columns": ["First Name", "Last Name", "Age", "Weight", "Is VIP"],
+												"data": [["Apple", "Cider", 25, 48.8, true], ["Banana", "Man", 18, 68, false],
+														["Zara", "Vuitton", 35, 75, true], ["Sandra", "Zawaska", 32, 55, false],
+														["Merlion", "Krabby", 23, 57.22, false]]},
+								"tablefile2": {"columns": ["First Name", "Last Name", "Age", "Weight", "Is VIP"],
+												"data": [["Apple", "Cider", 25, 48.8, true], ["Banana", "Man", 18, 68, false],
+														["Zara", "Vuitton", 35, 75, true], ["Sandra", "Zawaska", 32, 55, false],
+														["Merlion", "Krabby", 23, 57.22, false]]}
+								}`),
+			},
+			expTransformedResponse: response{
+				headers: map[string]string{
+					"Content-Type":   "application/json",
+					"Content-Length": "189",
+				},
+				body:       []byte(`{"code":422,"message":"preprocessing error: error executing preprocess operation: *pipeline.CreateTableOp: unable to create base table for entity_table: invalid input: object is not Slice"}`),
+				statusCode: 422,
+			},
+		},
+		{
 			name:         "simple postproces",
 			specYamlPath: "../../pipeline/testdata/valid_simple_postprocess.yaml",
 			mockFeasts:   []mockFeast{},
@@ -345,6 +379,25 @@ func TestServer_PredictHandler_StandardTransformer(t *testing.T) {
 				},
 				body:       []byte(`{"status":"ok"}`),
 				statusCode: 200,
+			},
+		},
+		{
+			name:         "table transformation; failed to encode due to nil value in test_time",
+			specYamlPath: "../../pipeline/testdata/valid_table_transform_preprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			rawRequest: request{
+				headers: map[string]string{
+					"Content-Type": "application/json",
+				},
+				body: []byte(`{"drivers":[{"id":1,"name":"driver-1","vehicle":"motorcycle","previous_vehicle":"suv","rating":4,"test_time":null},{"id":2,"name":"driver-2","vehicle":"sedan","previous_vehicle":"mpv","rating":3, "test_time": 15}],"customer":{"id":1111}}`),
+			},
+			expTransformedResponse: response{
+				headers: map[string]string{
+					"Content-Type":   "application/json",
+					"Content-Length": "194",
+				},
+				body:       []byte(`{"code":422,"message":"preprocessing error: error executing preprocess operation: *pipeline.TableTransformOp: invalid input: there is missing value on column test_time, cyclical encoding fails"}`),
+				statusCode: 422,
 			},
 		},
 		{

--- a/api/pkg/transformer/types/encoder/cyclical_encoder.go
+++ b/api/pkg/transformer/types/encoder/cyclical_encoder.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"time"
 
+	mErrors "github.com/gojek/merlin/pkg/errors"
 	"github.com/gojek/merlin/pkg/transformer/spec"
 	"github.com/gojek/merlin/pkg/transformer/types/converter"
 )
@@ -90,7 +91,7 @@ func NewCyclicalEncoder(config *spec.CyclicalEncoderConfig) (*CyclicalEncoder, e
 	byRange := config.GetByRange()
 	if byRange != nil {
 		if (byRange.Max - byRange.Min) < floatZero {
-			return nil, fmt.Errorf("max of cyclical range must be larger than min")
+			return nil, mErrors.NewInvalidInputError("max of cyclical range must be larger than min")
 		}
 
 		return &CyclicalEncoder{
@@ -130,7 +131,7 @@ func NewCyclicalEncoder(config *spec.CyclicalEncoderConfig) (*CyclicalEncoder, e
 		}, nil
 	}
 
-	return nil, fmt.Errorf("cyclical encoding config invalid or undefined")
+	return nil, mErrors.NewInvalidInputErrorf("cyclical encoding config invalid or undefined")
 }
 
 func (oe *CyclicalEncoder) Encode(values []interface{}, column string) (map[string]interface{}, error) {
@@ -145,7 +146,7 @@ func (oe *CyclicalEncoder) Encode(values []interface{}, column string) (map[stri
 		for _, val := range values {
 			// Check if value is missing
 			if val == nil {
-				return nil, fmt.Errorf("missing value")
+				return nil, mErrors.NewInvalidInputErrorf("there is missing value on column %s, cyclical encoding fails", column)
 			}
 
 			// Check if value is valid
@@ -164,7 +165,7 @@ func (oe *CyclicalEncoder) Encode(values []interface{}, column string) (map[stri
 		for _, val := range values {
 			// Check if value is missing
 			if val == nil {
-				return nil, fmt.Errorf("missing value")
+				return nil, mErrors.NewInvalidInputErrorf("there is missing value on column %s, cyclical encoding fails", column)
 			}
 
 			// Check if value is valid
@@ -253,7 +254,7 @@ func getCycleTime(periodType spec.PeriodType, t time.Time) (int, error) {
 		return elapsed, nil
 	}
 
-	return 0, fmt.Errorf("period type is undefined for this use case")
+	return 0, mErrors.NewInvalidInputError("period type is undefined for this use case")
 }
 
 // Convert time duration in days, hour, min, sec to number of seconds
@@ -304,7 +305,7 @@ func getUnitAngle(periodType spec.PeriodType, t time.Time) (float64, error) {
 		return unitYearInSec, nil
 	}
 
-	return 0, fmt.Errorf("period type is undefined for this use case")
+	return 0, mErrors.NewInvalidInputError("period type is undefined for this use case")
 }
 
 // test if a given year is leap year

--- a/api/pkg/transformer/types/encoder/cyclical_encoder_test.go
+++ b/api/pkg/transformer/types/encoder/cyclical_encoder_test.go
@@ -91,7 +91,7 @@ func TestNewCyclicalEncoder(t *testing.T) {
 				},
 			},
 			expectedEncoder: nil,
-			expectedErr:     fmt.Errorf("max of cyclical range must be larger than min"),
+			expectedErr:     fmt.Errorf("invalid input: max of cyclical range must be larger than min"),
 		},
 		{
 			desc: "Should fail - Max < Min",
@@ -104,7 +104,7 @@ func TestNewCyclicalEncoder(t *testing.T) {
 				},
 			},
 			expectedEncoder: nil,
-			expectedErr:     fmt.Errorf("max of cyclical range must be larger than min"),
+			expectedErr:     fmt.Errorf("invalid input: max of cyclical range must be larger than min"),
 		},
 		{
 			desc: "Should succeed - by epoch time: HOUR",
@@ -239,7 +239,7 @@ func TestNewCyclicalEncoder(t *testing.T) {
 				EncodeBy: &spec.CyclicalEncoderConfig_ByEpochTime{},
 			},
 			expectedEncoder: nil,
-			expectedErr:     fmt.Errorf("cyclical encoding config invalid or undefined"),
+			expectedErr:     fmt.Errorf("invalid input: cyclical encoding config invalid or undefined"),
 		},
 	}
 	for _, tC := range testCases {
@@ -279,7 +279,7 @@ func TestCyclicalEncode(t *testing.T) {
 				1641060000, // 3 Jan 2022, 18:00:00
 			},
 			expectedResult: nil,
-			expectedError:  fmt.Errorf("missing value"),
+			expectedError:  fmt.Errorf("invalid input: there is missing value on column col, cyclical encoding fails"),
 		},
 		{
 			desc: "Should fail: By Epoch time: Missing value",
@@ -295,7 +295,7 @@ func TestCyclicalEncode(t *testing.T) {
 				1641060000, // 3 Jan 2022, 18:00:00
 			},
 			expectedResult: nil,
-			expectedError:  fmt.Errorf("missing value"),
+			expectedError:  fmt.Errorf("invalid input: there is missing value on column col, cyclical encoding fails"),
 		},
 		{
 			desc: "Should fail: Invalid value",
@@ -580,28 +580,28 @@ func TestGetCycleTime(t *testing.T) {
 			periodType:        123,
 			epochTime:         time.Date(2021, 12, 31, 3, 15, 16, 0, time.UTC),
 			expectedCycleTime: 0,
-			expectedErr:       fmt.Errorf("period type is undefined for this use case"),
+			expectedErr:       fmt.Errorf("invalid input: period type is undefined for this use case"),
 		},
 		{
 			desc:              "Should fail - PeriodType: HOUR",
 			periodType:        spec.PeriodType_HOUR,
 			epochTime:         time.Date(2021, 12, 31, 3, 15, 16, 0, time.UTC),
 			expectedCycleTime: 0,
-			expectedErr:       fmt.Errorf("period type is undefined for this use case"),
+			expectedErr:       fmt.Errorf("invalid input: period type is undefined for this use case"),
 		},
 		{
 			desc:              "Should fail - PeriodType: DAY",
 			periodType:        spec.PeriodType_DAY,
 			epochTime:         time.Date(2021, 12, 31, 3, 15, 16, 0, time.UTC),
 			expectedCycleTime: 0,
-			expectedErr:       fmt.Errorf("period type is undefined for this use case"),
+			expectedErr:       fmt.Errorf("invalid input: period type is undefined for this use case"),
 		},
 		{
 			desc:              "Should fail - PeriodType: WEEK",
 			periodType:        spec.PeriodType_WEEK,
 			epochTime:         time.Date(2021, 12, 31, 3, 15, 16, 0, time.UTC),
 			expectedCycleTime: 0,
-			expectedErr:       fmt.Errorf("period type is undefined for this use case"),
+			expectedErr:       fmt.Errorf("invalid input: period type is undefined for this use case"),
 		},
 		{
 			desc:              "Should succeed - PeriodType: MONTH, leap",
@@ -821,28 +821,28 @@ func TestGetUnitAngle(t *testing.T) {
 			periodType:        123,
 			epochTime:         time.Date(2021, 12, 31, 3, 15, 16, 0, time.UTC),
 			expectedUnitAngle: 0,
-			expectedErr:       fmt.Errorf("period type is undefined for this use case"),
+			expectedErr:       fmt.Errorf("invalid input: period type is undefined for this use case"),
 		},
 		{
 			desc:              "Should fail - PeriodType: HOUR",
 			periodType:        spec.PeriodType_HOUR,
 			epochTime:         time.Date(2021, 12, 31, 3, 15, 16, 0, time.UTC),
 			expectedUnitAngle: 0,
-			expectedErr:       fmt.Errorf("period type is undefined for this use case"),
+			expectedErr:       fmt.Errorf("invalid input: period type is undefined for this use case"),
 		},
 		{
 			desc:              "Should fail - PeriodType: DAY",
 			periodType:        spec.PeriodType_DAY,
 			epochTime:         time.Date(2021, 12, 31, 3, 15, 16, 0, time.UTC),
 			expectedUnitAngle: 0,
-			expectedErr:       fmt.Errorf("period type is undefined for this use case"),
+			expectedErr:       fmt.Errorf("invalid input: period type is undefined for this use case"),
 		},
 		{
 			desc:              "Should fail - PeriodType: WEEK",
 			periodType:        spec.PeriodType_WEEK,
 			epochTime:         time.Date(2021, 12, 31, 3, 15, 16, 0, time.UTC),
 			expectedUnitAngle: 0,
-			expectedErr:       fmt.Errorf("period type is undefined for this use case"),
+			expectedErr:       fmt.Errorf("invalid input: period type is undefined for this use case"),
 		},
 		{
 			desc:              "Should succeed - PeriodType: MONTH, Jan",

--- a/api/pkg/transformer/types/encoder/ordinal_encoder.go
+++ b/api/pkg/transformer/types/encoder/ordinal_encoder.go
@@ -3,6 +3,7 @@ package encoder
 import (
 	"strings"
 
+	mErrors "github.com/gojek/merlin/pkg/errors"
 	"github.com/gojek/merlin/pkg/transformer/spec"
 	"github.com/gojek/merlin/pkg/transformer/types/converter"
 )
@@ -19,7 +20,7 @@ func NewOrdinalEncoder(config *spec.OrdinalEncoderConfig) (*OrdinalEncoder, erro
 	if trimmedDefaultValue != "" {
 		val, err := converter.ToTargetType(trimmedDefaultValue, config.TargetValueType)
 		if err != nil {
-			return nil, err
+			return nil, mErrors.NewInvalidInputError(err.Error())
 		}
 		defaultValue = val
 	}
@@ -30,7 +31,7 @@ func NewOrdinalEncoder(config *spec.OrdinalEncoderConfig) (*OrdinalEncoder, erro
 		trimmedTargetValue := strings.TrimSpace(targetValue)
 		tVal, err := converter.ToTargetType(trimmedTargetValue, config.TargetValueType)
 		if err != nil {
-			return nil, err
+			return nil, mErrors.NewInvalidInputError(err.Error())
 		}
 		mapping[originalValue] = tVal
 	}

--- a/api/pkg/transformer/types/encoder/ordinal_encoder_test.go
+++ b/api/pkg/transformer/types/encoder/ordinal_encoder_test.go
@@ -133,7 +133,7 @@ func TestNewOrdinalEncoder(t *testing.T) {
 				},
 			},
 			expectedEncoder: nil,
-			expectedErr:     fmt.Errorf(`strconv.Atoi: parsing "1one": invalid syntax`),
+			expectedErr:     fmt.Errorf(`invalid input: strconv.Atoi: parsing "1one": invalid syntax`),
 		},
 		{
 			desc: "Should return error, when default value is string but target type is INT",
@@ -146,7 +146,7 @@ func TestNewOrdinalEncoder(t *testing.T) {
 				},
 			},
 			expectedEncoder: nil,
-			expectedErr:     fmt.Errorf(`strconv.Atoi: parsing "zero": invalid syntax`),
+			expectedErr:     fmt.Errorf(`invalid input: strconv.Atoi: parsing "zero": invalid syntax`),
 		},
 		{
 			desc: "Should return error, when mapping target value is int but target type is boolean",
@@ -158,7 +158,7 @@ func TestNewOrdinalEncoder(t *testing.T) {
 				},
 			},
 			expectedEncoder: nil,
-			expectedErr:     fmt.Errorf(`strconv.ParseBool: parsing "2": invalid syntax`),
+			expectedErr:     fmt.Errorf(`invalid input: strconv.ParseBool: parsing "2": invalid syntax`),
 		},
 	}
 	for _, tC := range testCases {

--- a/api/pkg/transformer/types/scaler/scaler.go
+++ b/api/pkg/transformer/types/scaler/scaler.go
@@ -1,8 +1,7 @@
 package scaler
 
 import (
-	"fmt"
-
+	mErrors "github.com/gojek/merlin/pkg/errors"
 	"github.com/gojek/merlin/pkg/transformer/spec"
 )
 
@@ -19,7 +18,7 @@ func NewScaler(scalerSpec *spec.ScaleColumn) (Scaler, error) {
 	case *spec.ScaleColumn_MinMaxScalerConfig:
 		scalerImpl = &MinMaxScaler{cfg.MinMaxScalerConfig}
 	default:
-		return nil, fmt.Errorf("scaler config has unexpected type %T", cfg)
+		return nil, mErrors.NewInvalidInputErrorf("scaler config has unexpected type %T", cfg)
 	}
 	return scalerImpl, nil
 }

--- a/api/pkg/transformer/types/series/series.go
+++ b/api/pkg/transformer/types/series/series.go
@@ -6,6 +6,7 @@ import (
 
 	upiv1 "github.com/caraml-dev/universal-prediction-interface/gen/go/grpc/caraml/upi/v1"
 	"github.com/go-gota/gota/series"
+	mErrors "github.com/gojek/merlin/pkg/errors"
 	"github.com/gojek/merlin/pkg/transformer/types/converter"
 )
 
@@ -63,7 +64,7 @@ func NewInferType(values interface{}, seriesName string) (*Series, error) {
 	seriesType := detectType(values)
 	seriesValues, err := castValues(values, seriesType)
 	if err != nil {
-		return nil, err
+		return nil, mErrors.NewInvalidInputError(err.Error())
 	}
 
 	return New(seriesValues, seriesType, seriesName), nil
@@ -114,7 +115,7 @@ func (s *Series) toUPIColumn() (*upiv1.Column, error) {
 	case String:
 		upiColType = upiv1.Type_TYPE_STRING
 	default:
-		return nil, fmt.Errorf("type %v is not supported in UPI", s.Type())
+		return nil, mErrors.NewInvalidInputErrorf("type %v is not supported in UPI", s.Type())
 	}
 
 	return &upiv1.Column{
@@ -142,7 +143,7 @@ func (s *Series) IsNumeric() error {
 			return nil
 		}
 	}
-	return fmt.Errorf("this series type is not numeric but %s", seriesType)
+	return mErrors.NewInvalidInputErrorf("this series type is not numeric but %s", seriesType)
 }
 
 func (s *Series) And(right *Series) (*Series, error) {

--- a/api/pkg/transformer/types/series/series_test.go
+++ b/api/pkg/transformer/types/series/series_test.go
@@ -1526,14 +1526,14 @@ func TestConvertToUPIColumns(t *testing.T) {
 					New([]bool{false, true, false}, Bool, "col_bool"),
 				},
 			},
-			expErr: fmt.Errorf("type bool is not supported in UPI"),
+			expErr: fmt.Errorf("invalid input: type bool is not supported in UPI"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ConvertToUPIColumns(tt.args.cols)
-			assert.Equal(t, tt.expErr, err)
 			if tt.expErr != nil {
+				assert.EqualError(t, tt.expErr, err.Error())
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {

--- a/api/pkg/transformer/types/table/table_test.go
+++ b/api/pkg/transformer/types/table/table_test.go
@@ -261,14 +261,14 @@ func Test_ToUPITable(t *testing.T) {
 				series.New([]string{"row1", "row2"}, series.String, "row_id"),
 			),
 			tableName:   "new_table",
-			expectedErr: fmt.Errorf("type bool is not supported in UPI"),
+			expectedErr: fmt.Errorf("invalid input: type bool is not supported in UPI"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.table.ToUPITable(tt.tableName)
-			assert.Equal(t, tt.expectedErr, err)
 			if tt.expectedErr != nil {
+				assert.EqualError(t, tt.expectedErr, err.Error())
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {

--- a/python/pyfunc-server/pyfuncserver/protocol/upi/server.py
+++ b/python/pyfunc-server/pyfuncserver/protocol/upi/server.py
@@ -20,7 +20,6 @@ class PredictionService(upi_pb2_grpc.UniversalPredictionServiceServicer):
         self._model = model
 
     def PredictValues(self, request, context):
-        time.sleep(10)
         return self._model.upiv1_predict(request=request, context=context)
 
 

--- a/python/pyfunc-server/pyfuncserver/protocol/upi/server.py
+++ b/python/pyfunc-server/pyfuncserver/protocol/upi/server.py
@@ -10,8 +10,6 @@ from grpc_health.v1 import health_pb2_grpc
 
 from pyfuncserver.config import Config
 from pyfuncserver.model.model import PyFuncModel
-import time
-
 
 class PredictionService(upi_pb2_grpc.UniversalPredictionServiceServicer):
     def __init__(self, model: PyFuncModel):

--- a/python/pyfunc-server/pyfuncserver/protocol/upi/server.py
+++ b/python/pyfunc-server/pyfuncserver/protocol/upi/server.py
@@ -10,6 +10,7 @@ from grpc_health.v1 import health_pb2_grpc
 
 from pyfuncserver.config import Config
 from pyfuncserver.model.model import PyFuncModel
+import time
 
 
 class PredictionService(upi_pb2_grpc.UniversalPredictionServiceServicer):
@@ -19,6 +20,7 @@ class PredictionService(upi_pb2_grpc.UniversalPredictionServiceServicer):
         self._model = model
 
     def PredictValues(self, request, context):
+        time.sleep(10)
         return self._model.upiv1_predict(request=request, context=context)
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Currently all error that happens in standard transformer is treated as 500(http) or 13(grpc). This PR will try to differentiate error in standard transformer,
* if error due to bad input from our user it will return 400 for http and 3 for grpc
* if facing timeout it will return 4 for grpc
* the rest if treated as 500 for http or 13 for grpc
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
