### PR TITLE
Fix http path for liveness probe due to `/` is not found in some model predictor

### DIFF
--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -183,7 +183,7 @@ func createPredictorSpec(modelService *models.Service, config *config.Deployment
 	envVarsMap := envVars.ToMap()
 	if !strings.EqualFold(envVarsMap[envOldDisableLivenessProbe], "true") &&
 		!strings.EqualFold(envVarsMap[envDisableLivenessProbe], "true") {
-		livenessProbeConfig = createLivenessProbeSpec(modelService.Protocol)
+		livenessProbeConfig = createLivenessProbeSpec(modelService.Protocol, fmt.Sprintf("/v1/models/%s", modelService.Name))
 	}
 
 	containerPorts := createContainerPorts(modelService.Protocol)
@@ -328,7 +328,7 @@ func (t *InferenceServiceTemplater) createTransformerSpec(modelService *models.S
 	envVarsMap := envVars.ToMap()
 	if !strings.EqualFold(envVarsMap[envOldDisableLivenessProbe], "true") &&
 		!strings.EqualFold(envVarsMap[envDisableLivenessProbe], "true") {
-		livenessProbeConfig = createLivenessProbeSpec(modelService.Protocol)
+		livenessProbeConfig = createLivenessProbeSpec(modelService.Protocol, "/")
 	}
 
 	containerPorts := createContainerPorts(modelService.Protocol)
@@ -444,11 +444,11 @@ func createGRPCLivenessProbe(port int) *corev1.Probe {
 	}
 }
 
-func createLivenessProbeSpec(protocol prt.Protocol) *corev1.Probe {
+func createLivenessProbeSpec(protocol prt.Protocol, httpPath string) *corev1.Probe {
 	if protocol == prt.UpiV1 {
 		return createGRPCLivenessProbe(defaultGRPCPort)
 	}
-	return createHTTPGetLivenessProbe("/", defaultHTTPPort)
+	return createHTTPGetLivenessProbe(httpPath, defaultHTTPPort)
 }
 
 func createPredictorHost(modelService *models.Service) string {

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -178,7 +178,6 @@ func createPredictorSpec(modelService *models.Service, config *config.Deployment
 	}
 
 	// liveness probe config. if env var to disable != true or not set, it will default to enabled
-	// only applicable for protocol = HttpJson for now
 	var livenessProbeConfig *corev1.Probe = nil
 	envVarsMap := envVars.ToMap()
 	if !strings.EqualFold(envVarsMap[envOldDisableLivenessProbe], "true") &&

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -153,8 +153,8 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson)
-	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1)
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	tests := []struct {
 		name               string
@@ -1569,12 +1569,12 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson)
-	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1)
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson)
-	transformerProbeConfigUPI := createLivenessProbeSpec(protocol.UpiV1)
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
+	transformerProbeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, "/")
 	tests := []struct {
 		name     string
 		modelSvc *models.Service
@@ -2085,10 +2085,10 @@ func TestCreateInferenceServiceSpecWithLogger(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson)
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson)
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
 
 	tests := []struct {
 		name     string
@@ -2549,10 +2549,10 @@ func TestPatchInferenceServiceSpec(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson)
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson)
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
 
 	one := 1
 	minReplica := 1
@@ -3215,7 +3215,7 @@ func TestCreateTransformerSpec(t *testing.T) {
 	memoryLimit.Add(memoryRequest)
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson)
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
 
 	modelSvc := &models.Service{
 		Name:         "model-1",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Fix http path for liveness probe from `/` into `/v1/models/{model_full_name}`, this issue happens for tensorflow model

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
