### PR TITLE
Update version.endpoint() to reuse _version_endpoints attribute

### DIFF
--- a/python/sdk/merlin/endpoint.py
+++ b/python/sdk/merlin/endpoint.py
@@ -89,7 +89,7 @@ class VersionEndpoint:
     @property
     def env_vars(self) -> Dict[str, str]:
         env_vars = {}
-        if self._env_vars is not None:
+        if self._env_vars:
             for ev in self._env_vars:
                 env_vars[ev.name] = ev.value
         return env_vars

--- a/python/sdk/merlin/endpoint.py
+++ b/python/sdk/merlin/endpoint.py
@@ -16,8 +16,9 @@ from enum import Enum
 from typing import Dict
 
 import client
-from merlin.autoscaling import AutoscalingPolicy, MetricsType, RAW_DEPLOYMENT_DEFAULT_AUTOSCALING_POLICY, \
-    SERVERLESS_DEFAULT_AUTOSCALING_POLICY
+from merlin.autoscaling import (RAW_DEPLOYMENT_DEFAULT_AUTOSCALING_POLICY,
+                                SERVERLESS_DEFAULT_AUTOSCALING_POLICY,
+                                AutoscalingPolicy, MetricsType)
 from merlin.deployment_mode import DeploymentMode
 from merlin.environment import Environment
 from merlin.logger import Logger
@@ -88,8 +89,9 @@ class VersionEndpoint:
     @property
     def env_vars(self) -> Dict[str, str]:
         env_vars = {}
-        for ev in self._env_vars:
-            env_vars[ev.name] = ev.value
+        if self._env_vars is not None:
+            for ev in self._env_vars:
+                env_vars[ev.name] = ev.value
         return env_vars
 
     @property

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1119,7 +1119,6 @@ class ModelVersion:
               f"\nView model version logs: {log_url}")
 
         self._version_endpoints = self.list_endpoint()
-        print("deploy: self._version_endpoints", self._version_endpoints)
 
         return VersionEndpoint(endpoint, log_url)
 

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -667,7 +667,7 @@ class ModelVersion:
         Return endpoint of this model version that is deployed in default
         environment
 
-        :return: Endpoint or None
+        :return: VersionEndpoint or None
         """
 
         # For backward compatibility, we called VersionEndpoint API if _version_endpoints empty.
@@ -1117,6 +1117,9 @@ class ModelVersion:
         log_url = f"{self.url}/{self.id}/endpoints/{endpoint.id}/logs"
         print(f"Model {model.name} version {self.id} is deployed."
               f"\nView model version logs: {log_url}")
+
+        self._version_endpoints = self.list_endpoint()
+        print("deploy: self._version_endpoints", self._version_endpoints)
 
         return VersionEndpoint(endpoint, log_url)
 

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -670,7 +670,15 @@ class ModelVersion:
         :return: Endpoint or None
         """
 
-        for endpoint in self._version_endpoints:
+        # For backward compatibility, we called VersionEndpoint API if _version_endpoints empty.
+        endpoints = self._version_endpoints
+        if endpoints is None:
+            endpoint_api = EndpointApi(self._api_client)
+            endpoints = endpoint_api. \
+                models_model_id_versions_version_id_endpoint_get(
+                    model_id=self.model.id, version_id=self.id)
+
+        for endpoint in endpoints:
             if endpoint.environment.is_default:
                 return VersionEndpoint(endpoint)
 

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -18,42 +18,45 @@ import re
 import shutil
 import tempfile
 import warnings
-import yaml
-
 from datetime import datetime
 from enum import Enum
-from time import sleep
 from sys import version_info
-from typing import Dict, List, Optional, Tuple, Union, Any
+from time import sleep
+from typing import Any, Dict, List, Optional, Tuple, Union
 
+import client
 import docker
-import mlflow
 import pyprind
+import yaml
+from client import (EndpointApi, EnvironmentApi, ModelEndpointsApi, ModelsApi,
+                    SecretApi, VersionApi)
 from docker import APIClient
 from docker.errors import BuildError
 from docker.models.containers import Container
-from mlflow.pyfunc import PythonModel
-from mlflow.entities import Run, RunData
-from mlflow.exceptions import MlflowException
-
-import client
-from client import EndpointApi, EnvironmentApi, ModelEndpointsApi, ModelsApi, SecretApi, VersionApi
-from merlin.autoscaling import AutoscalingPolicy, RAW_DEPLOYMENT_DEFAULT_AUTOSCALING_POLICY, \
-    SERVERLESS_DEFAULT_AUTOSCALING_POLICY
+from merlin.autoscaling import (RAW_DEPLOYMENT_DEFAULT_AUTOSCALING_POLICY,
+                                SERVERLESS_DEFAULT_AUTOSCALING_POLICY,
+                                AutoscalingPolicy)
 from merlin.batch.config import PredictionJobConfig
 from merlin.batch.job import PredictionJob
 from merlin.batch.sink import BigQuerySink
 from merlin.batch.source import BigQuerySource
 from merlin.deployment_mode import DeploymentMode
-from merlin.docker.docker import copy_pyfunc_dockerfile, copy_standard_dockerfile
+from merlin.docker.docker import (copy_pyfunc_dockerfile,
+                                  copy_standard_dockerfile)
 from merlin.endpoint import ModelEndpoint, Status, VersionEndpoint
+from merlin.logger import Logger
 from merlin.protocol import Protocol
 from merlin.resource_request import ResourceRequest
 from merlin.transformer import Transformer
-from merlin.logger import Logger
-from merlin.util import autostr, download_files_from_gcs, guess_mlp_ui_url, valid_name_check
+from merlin.util import (autostr, download_files_from_gcs, guess_mlp_ui_url,
+                         valid_name_check)
 from merlin.validation import validate_model_dir
 from merlin.version import VERSION
+from mlflow.entities import Run, RunData
+from mlflow.exceptions import MlflowException
+from mlflow.pyfunc import PythonModel
+
+import mlflow
 from merlin import pyfunc
 
 # Ensure backward compatibility after moving PyFuncModel and PyFuncV2Model to pyfunc.py
@@ -666,12 +669,8 @@ class ModelVersion:
 
         :return: Endpoint or None
         """
-        endpoint_api = EndpointApi(self._api_client)
-        ep_list = endpoint_api. \
-            models_model_id_versions_version_id_endpoint_get(
-                model_id=self.model.id, version_id=self.id)
 
-        for endpoint in ep_list:
+        for endpoint in self._version_endpoints:
             if endpoint.environment.is_default:
                 return VersionEndpoint(endpoint)
 
@@ -869,9 +868,9 @@ class ModelVersion:
         """
         mlflow.log_artifact(local_path, artifact_path)
 
-    def log_pyfunc_model(self, 
-                        model_instance: PythonModel, 
-                        conda_env: Union[str, Dict[str, Any]], 
+    def log_pyfunc_model(self,
+                        model_instance: PythonModel,
+                        conda_env: Union[str, Dict[str, Any]],
                         code_dir: Optional[List[str]] = None,
                         artifacts: Dict[str, str] =None):
         """
@@ -1512,5 +1511,5 @@ def _process_conda_env(conda_env: Union[str, Dict[str, Any]], python_version: st
     # Replace python dependency to match minor version
     new_conda_env['dependencies'] = ([f'python={python_version}'] +
         [spec for spec in new_conda_env['dependencies'] if not match_dependency(spec, 'python')])
-        
+
     return new_conda_env

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -671,14 +671,10 @@ class ModelVersion:
         """
 
         # For backward compatibility, we called VersionEndpoint API if _version_endpoints empty.
-        endpoints = self._version_endpoints
-        if endpoints is None:
-            endpoint_api = EndpointApi(self._api_client)
-            endpoints = endpoint_api. \
-                models_model_id_versions_version_id_endpoint_get(
-                    model_id=self.model.id, version_id=self.id)
+        if self._version_endpoints is None:
+            self._version_endpoints = self.list_endpoint()
 
-        for endpoint in endpoints:
+        for endpoint in self._version_endpoints:
             if endpoint.environment.is_default:
                 return VersionEndpoint(endpoint)
 

--- a/python/sdk/test/integration_test.py
+++ b/python/sdk/test/integration_test.py
@@ -13,23 +13,20 @@
 # limitations under the License.
 import json
 import os
+from test.utils import undeploy_all_version
 from time import sleep
 
-
-import pytest
 import pandas as pd
+import pytest
+from merlin.endpoint import Status
+from merlin.logger import Logger, LoggerConfig, LoggerMode
+from merlin.model import ModelType
+from merlin.resource_request import ResourceRequest
+from merlin.transformer import StandardTransformer, Transformer
 from recursive_diff import recursive_eq
 
 import merlin
 from merlin import DeploymentMode
-from merlin.endpoint import Status
-from merlin.model import ModelType
-from merlin.resource_request import ResourceRequest
-from merlin.transformer import Transformer, StandardTransformer
-from merlin.logger import Logger, LoggerConfig, LoggerMode
-from test.utils import undeploy_all_version
-
-
 
 request_json = {"instances": [[2.8, 1.0, 6.8, 0.4], [3.1, 1.4, 4.5, 1.6]]}
 tensorflow_request_json = {
@@ -262,7 +259,7 @@ def test_set_traffic(integration_test_url, project_name, use_google_oauth, reque
     # Try to undeploy serving model version. It must be fail
     with pytest.raises(Exception):
         assert merlin.undeploy(v)
-        
+
     merlin.stop_serving_traffic(endpoint.environment_name)
 
     # Undeploy other running model version endpoints
@@ -303,7 +300,7 @@ def test_serve_traffic(integration_test_url, project_name, use_google_oauth, req
     # Try to undeploy serving model version. It must be fail
     with pytest.raises(Exception):
         assert merlin.undeploy(v)
-      
+
     merlin.stop_serving_traffic(model_endpoint.environment_name)
 
     # Undeploy other running model version endpoints
@@ -380,7 +377,7 @@ def test_resource_request(integration_test_url, project_name, deployment_mode, u
 # https://github.com/kserve/kserve/issues/2142
 # Logging is not supported yet in raw_deployment
 @pytest.mark.integration
-@pytest.mark.parametrize("deployment_mode", [DeploymentMode.RAW_DEPLOYMENT, DeploymentMode.SERVERLESS]) 
+@pytest.mark.parametrize("deployment_mode", [DeploymentMode.RAW_DEPLOYMENT, DeploymentMode.SERVERLESS])
 def test_logger(integration_test_url, project_name, deployment_mode, use_google_oauth, requests):
     merlin.set_url(integration_test_url, use_google_oauth=use_google_oauth)
     merlin.set_project(project_name)
@@ -914,7 +911,7 @@ def test_deployment_mode_for_serving_model(integration_test_url, project_name, u
     assert resp.status_code == 200
     assert resp.json() is not None
     assert len(resp.json()["predictions"]) == len(tensorflow_request_json["instances"])
-    
+
     merlin.stop_serving_traffic(model_endpoint.environment_name)
     undeploy_all_version()
 

--- a/python/sdk/test/model_test.py
+++ b/python/sdk/test/model_test.py
@@ -14,25 +14,24 @@
 
 import json
 import types
-import pytest
-
-import client
-import merlin
-from merlin import DeploymentMode, MetricsType
-from merlin import AutoscalingPolicy
-from merlin.autoscaling import RAW_DEPLOYMENT_DEFAULT_AUTOSCALING_POLICY, \
-    SERVERLESS_DEFAULT_AUTOSCALING_POLICY
-from merlin.model import ModelType
-from urllib3_mock import Responses
 from unittest.mock import patch
 
+import client
 import client as cl
+import pytest
+from merlin.autoscaling import (RAW_DEPLOYMENT_DEFAULT_AUTOSCALING_POLICY,
+                                SERVERLESS_DEFAULT_AUTOSCALING_POLICY)
 from merlin.batch.config import PredictionJobConfig, ResultType
 from merlin.batch.job import JobStatus
 from merlin.batch.sink import BigQuerySink, SaveMode
 from merlin.batch.source import BigQuerySource
 from merlin.endpoint import VersionEndpoint
+from merlin.model import ModelType
 from merlin.protocol import Protocol
+from urllib3_mock import Responses
+
+import merlin
+from merlin import AutoscalingPolicy, DeploymentMode, MetricsType
 
 responses = Responses('requests.packages.urllib3')
 
@@ -196,28 +195,6 @@ class TestProject:
 
 
 class TestModelVersion:
-    @responses.activate
-    def test_endpoint(self, version):
-        responses.add("GET", '/v1/models/1/versions/1/endpoint',
-                      body=json.dumps([ep2.to_dict()]),
-                      status=200,
-                      content_type='application/json')
-
-        ep = version.endpoint
-        assert ep is None
-        responses.reset()
-
-        responses.add("GET", '/v1/models/1/versions/1/endpoint',
-                      body=json.dumps([ep1.to_dict(), ep2.to_dict()]),
-                      status=200,
-                      content_type='application/json')
-
-        ep = version.endpoint
-        assert ep.id == ep1.id
-        assert ep.status.value == ep1.status
-        assert ep.environment_name == ep1.environment_name
-        assert ep.url.startswith(ep1.url)
-
     @responses.activate
     def test_list_endpoint(self, version):
         responses.add("GET", '/v1/models/1/versions/1/endpoint',
@@ -967,7 +944,7 @@ def test_process_conda_env():
             },
         ],
     }
-  
+
     new_conda = merlin.model._process_conda_env(conda_env=conda, python_version="3.7.*")
     assert "python=3.7.*" in new_conda["dependencies"]
 

--- a/python/sdk/test/model_test.py
+++ b/python/sdk/test/model_test.py
@@ -218,6 +218,11 @@ class TestModelVersion:
                       body=json.dumps(ep1.to_dict()),
                       status=200,
                       content_type='application/json')
+        responses.add("GET", '/v1/models/1/versions/1/endpoint',
+                      body=json.dumps([ep1.to_dict()]),
+                      status=200,
+                      content_type='application/json')
+
         endpoint = version.deploy(environment_name=env_1.name)
 
         assert endpoint.id == ep1.id
@@ -240,6 +245,11 @@ class TestModelVersion:
                       body=json.dumps(upi_ep.to_dict()),
                       status=200,
                       content_type='application/json')
+        responses.add("GET", '/v1/models/1/versions/1/endpoint',
+                      body=json.dumps([upi_ep.to_dict()]),
+                      status=200,
+                      content_type='application/json')
+
         endpoint = version.deploy(environment_name=env_1.name)
 
         assert endpoint.id == upi_ep.id
@@ -262,6 +272,11 @@ class TestModelVersion:
                       body=json.dumps(ep3.to_dict()),
                       status=200,
                       content_type='application/json')
+        responses.add("GET", '/v1/models/1/versions/1/endpoint',
+                      body=json.dumps([ep3.to_dict()]),
+                      status=200,
+                      content_type='application/json')
+
         endpoint = version.deploy(environment_name=env_1.name, deployment_mode=DeploymentMode.RAW_DEPLOYMENT)
 
         assert endpoint.id == ep3.id
@@ -283,6 +298,11 @@ class TestModelVersion:
                       body=json.dumps(ep4.to_dict()),
                       status=200,
                       content_type='application/json')
+        responses.add("GET", '/v1/models/1/versions/1/endpoint',
+                      body=json.dumps([ep4.to_dict()]),
+                      status=200,
+                      content_type='application/json')
+
         endpoint = version.deploy(environment_name=env_1.name,
                                   autoscaling_policy=AutoscalingPolicy(metrics_type=MetricsType.CPU_UTILIZATION,
                                                                        target_value=10))
@@ -318,6 +338,11 @@ class TestModelVersion:
                       body=json.dumps(ep1.to_dict()),
                       status=200,
                       content_type='application/json')
+        responses.add("GET", '/v1/models/1/versions/1/endpoint',
+                      body=json.dumps([ep1.to_dict()]),
+                      status=200,
+                      content_type='application/json')
+
         endpoint = version.deploy()
 
         assert endpoint.id == ep1.id

--- a/scripts/e2e/run-e2e.sh
+++ b/scripts/e2e/run-e2e.sh
@@ -33,4 +33,4 @@ kubectl create namespace ${E2E_PROJECT_NAME} --dry-run=client -o yaml | kubectl 
 cd ../../python/sdk
 pip install pipenv==2022.8.19
 pipenv install --dev --skip-lock --python ${PYTHON_VERSION}
-pipenv run pytest -n=4 -W=ignore --cov=merlin -m "not (feast or batch or pyfunc or local_server_test or cli or customtransformer)"
+pipenv run pytest -n=8 -W=ignore --cov=merlin -m "not (feast or batch or pyfunc or local_server_test or cli or customtransformer)"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Currently, in Python SDK, Version's endpoint() method implementations call GetVersionEndpoints API instead of reusing the existing `_version_endpoints` attribute that already got the data.

By reusing the `_version_endpoints`, we can cut the call to the Merlin server which improves the latency and reduce Merlin server workload.

```
Old implementation latency: 0.4594380855560303 second
New implementation latency: 0.00037217140197753906 second
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
