### PR TITLE
Refactor prometheus middleware to only wrap certain routes

### DIFF
--- a/api/pkg/transformer/executor/transformer.go
+++ b/api/pkg/transformer/executor/transformer.go
@@ -131,7 +131,6 @@ func (st *standardTransformer) Execute(ctx context.Context, requestBody types.JS
 		if env.IsPostProcessOpExist() {
 			resp.Tracing.PostprocessTracing = env.PostprocessTracingDetail()
 		}
-		st.logger.Debug("executor tracing", zap.Any("tracing_details", resp.Tracing))
 	}
 
 	return resp


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Refactor Prometheus middleware to only wrap routes -- excluding raw routes such as Logs API.

The current implementation of Prometheus middleware returns 500 for Logs API. Logs API is using http.Flusher which might need (if it's possible) to be used together with our `statusCodeRecorder`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes Logs API not working

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Updated unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
