### PR TITLE
Fix log API

### DIFF
--- a/api/api/router.go
+++ b/api/api/router.go
@@ -281,6 +281,12 @@ func (r *statusCodeRecorder) WriteHeader(statusCode int) {
 	r.ResponseWriter.WriteHeader(statusCode)
 }
 
+func (r *statusCodeRecorder) Flush() {
+	if flusher, ok := r.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 // prometheusMiddleware implements mux.MiddlewareFunc.
 func prometheusMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Existing log api implementation requires the `http.ResponseWriter` to implement `http.Flusher` interface. By default `http.ResponseWriter` implements `http.Flusher`, however, due to https://github.com/gojek/merlin/pull/323 this is broken. 
This PR address the issue by:
1. Relax the requirement of log API to only use `Flush` when the passed `http.ResponseWriter` implements `http.Flusher`, to avoid other issue in the future where any new middlerware break the requirement above. 
2. Add `Flush` method to the prometheus middleware.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->
None


**Checklist**

- [X] Tested locally