### PR TITLE
Fix Pipenv running different Python version

### DIFF
--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -43,6 +43,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+    env:
+      PIPENV_DEFAULT_PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -82,6 +84,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+    env:
+      PIPENV_DEFAULT_PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -112,6 +116,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+    env:
+      PIPENV_DEFAULT_PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -59,6 +59,7 @@ jobs:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-pipenv-batch-predictor
       - name: Check Python version
+        working-directory: ./python/batch-predictor
         run: |
           python -V
           pip -V

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Check Python version
         run: |
           python -V
-          which python
           pip -V
+          which python
           which pip
       - name: Install dependencies
         working-directory: ./python/batch-predictor

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -68,6 +68,7 @@ jobs:
         working-directory: ./python/batch-predictor
         run: |
           python -m pip install pipenv
+          env | grep PIPENV
           make setup
       - name: Run batch-predictor test
         working-directory: ./python/batch-predictor

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -45,7 +45,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v3
@@ -75,7 +75,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v3
@@ -105,7 +105,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v3
@@ -350,7 +350,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.E2E_PYTHON_VERSION }}
       - uses: actions/cache@v3

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install dependencies
         working-directory: ./python/batch-predictor
         run: |
-          pip install pipenv==2022.8.19
+          python -m pip install pipenv
           make setup
       - name: Run batch-predictor test
         working-directory: ./python/batch-predictor

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -58,6 +58,12 @@ jobs:
         with:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-pipenv-batch-predictor
+      - name: Check Python version
+        run: |
+          python -V
+          which python
+          pip -V
+          which pip
       - name: Install dependencies
         working-directory: ./python/batch-predictor
         run: |

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -64,6 +64,7 @@ jobs:
           pip -V
           which python
           which pip
+          make which-python
       - name: Install dependencies
         working-directory: ./python/batch-predictor
         run: |

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install dependencies
         working-directory: ./python/batch-predictor
         run: |
-          pip install pipenv
+          pip install pipenv==2022.8.19
           make setup
       - name: Run batch-predictor test
         working-directory: ./python/batch-predictor

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -68,8 +68,8 @@ jobs:
         working-directory: ./python/batch-predictor
         run: |
           python -m pip install pipenv
-          env | grep PIPENV
-          make setup
+          env
+          pipenv install --skip-lock -e .[test]
       - name: Run batch-predictor test
         working-directory: ./python/batch-predictor
         run: make unit-test

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -11,7 +11,6 @@ env:
   ARTIFACT_RETENTION_DAYS: 7
   DOCKER_BUILDKIT: 1
   GO_VERSION: 1.18
-  PYTHON_VERSION: "3.10"
 
 jobs:
   create-version:
@@ -343,6 +342,7 @@ jobs:
       LOCAL_REGISTRY: "dev.localhost"
       INGRESS_HOST: "127.0.0.1.nip.io"
       MLP_CHART_VERSION: 0.3.4
+      E2E_PYTHON_VERSION: "3.10"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -352,7 +352,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.E2E_PYTHON_VERSION }}
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
@@ -399,7 +399,7 @@ jobs:
         timeout-minutes: 30
         id: run-e2e-test
         working-directory: merlin/scripts/e2e
-        run: ./run-e2e.sh ${{ env.INGRESS_HOST }} ${{ env.PYTHON_VERSION }}
+        run: ./run-e2e.sh ${{ env.INGRESS_HOST }} ${{ env.E2E_PYTHON_VERSION }}
       - name: "Debug"
         if: always()
         continue-on-error: true

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -52,9 +52,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
       - uses: actions/cache@v3
         with:
           path: ~/.local/share/virtualenvs
@@ -82,9 +82,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
       - uses: actions/cache@v3
         with:
           path: ~/.local/share/virtualenvs
@@ -112,9 +112,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
       - uses: actions/cache@v3
         with:
           path: ~/.local/share/virtualenvs
@@ -356,9 +356,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
       - uses: actions/cache@v3
         with:
           path: ~/.local/share/virtualenvs

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -60,20 +60,11 @@ jobs:
         with:
           path: ~/.local/share/virtualenvs
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-pipenv-batch-predictor
-      - name: Check Python version
-        working-directory: ./python/batch-predictor
-        run: |
-          python -V
-          pip -V
-          which python
-          which pip
-          make which-python
       - name: Install dependencies
         working-directory: ./python/batch-predictor
         run: |
-          python -m pip install pipenv
-          env
-          pipenv install --skip-lock -e .[test]
+          pip install pipenv
+          make setup
       - name: Run batch-predictor test
         working-directory: ./python/batch-predictor
         run: make unit-test

--- a/python/batch-predictor/Makefile
+++ b/python/batch-predictor/Makefile
@@ -22,8 +22,3 @@ unit-test: type_check
 proto:
 	go get github.com/mitchellh/protoc-gen-go-json
 	protoc -I=. --python_out=merlinpyspark --mypy_out=spec --go_out=pkg/ --go-json_out=pkg/ --go_opt=paths=source_relative spec/*.proto
-
-.PHONY: which-python
-which-python:
-	which python
-	python -V

--- a/python/batch-predictor/Makefile
+++ b/python/batch-predictor/Makefile
@@ -22,3 +22,8 @@ unit-test: type_check
 proto:
 	go get github.com/mitchellh/protoc-gen-go-json
 	protoc -I=. --python_out=merlinpyspark --mypy_out=spec --go_out=pkg/ --go-json_out=pkg/ --go_opt=paths=source_relative spec/*.proto
+
+.PHONY: which-python
+which-python:
+	which python
+	python -V

--- a/python/pyfunc-server/Makefile
+++ b/python/pyfunc-server/Makefile
@@ -1,18 +1,18 @@
 
 .PHONY: dev_install
 dev_install:
-	pipenv install --skip-lock -e .[test]
+	python -m pipenv install --skip-lock -e .[test]
 
 .PHONY: setup
 setup: dev_install
 
 .PHONY: test
 test: type_check
-	pipenv run pytest -W ignore -s
+	python -m pipenv run pytest -W ignore -s
 
 .PHONY: type_check
 type_check:
-	pipenv run mypy --ignore-missing-imports pyfuncserver
+	python -m pipenv run mypy --ignore-missing-imports pyfuncserver
 
 .PHONY: benchmark
 benchmark:

--- a/python/pyfunc-server/Makefile
+++ b/python/pyfunc-server/Makefile
@@ -1,18 +1,18 @@
 
 .PHONY: dev_install
 dev_install:
-	python -m pipenv install --skip-lock -e .[test] --verbose
+	pipenv install --skip-lock -e .[test] --verbose
 
 .PHONY: setup
 setup: dev_install
 
 .PHONY: test
 test: type_check
-	python -m pipenv run pytest -W ignore -s
+	pipenv run pytest -W ignore -s
 
 .PHONY: type_check
 type_check:
-	python -m pipenv run mypy --ignore-missing-imports pyfuncserver
+	pipenv run mypy --ignore-missing-imports pyfuncserver
 
 .PHONY: benchmark
 benchmark:

--- a/python/pyfunc-server/Makefile
+++ b/python/pyfunc-server/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: dev_install
 dev_install:
-	python -m pipenv install --skip-lock -e .[test]
+	python -m pipenv install --skip-lock -e .[test] --verbose
 
 .PHONY: setup
 setup: dev_install

--- a/python/sdk/Makefile
+++ b/python/sdk/Makefile
@@ -4,7 +4,7 @@ setup:
 
 .PHONY: type_check
 type_check:
-	@pipenv run mypy --ignore-missing-imports --allow-untyped-globals  merlin
+	@pipenv run mypy --ignore-missing-imports --allow-untyped-globals --implicit-optional merlin
 
 .PHONY: test
 test: type_check

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -38,6 +38,7 @@ REQUIRES = [
     "PyYAML>=5.4",
     "six>=1.10",
     "urllib3>=1.23",
+    "numpy<=1.23.5", # Temporary pin numpy due to https://numpy.org/doc/stable/release/1.20.0-notes.html#numpy-1-20-0-release-notes
 ]
 
 TEST_REQUIRES = [

--- a/python/sdk/test/integration_test.py
+++ b/python/sdk/test/integration_test.py
@@ -214,7 +214,8 @@ def test_pytorch(integration_test_url, project_name, use_google_oauth, requests)
 
     with merlin.new_model_version() as v:
         merlin.log_model(model_dir=model_dir)
-        endpoint = merlin.deploy()
+        resource_request = ResourceRequest(1, 1, "100m", "200Mi")
+        endpoint = merlin.deploy(v, resource_request=resource_request)
 
     resp = requests.post(f"{endpoint.url}", json=request_json)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

We are using pipenv to manage dependencies, virtual environment, and executing pytest. However, as per the pipenv's documentation [here](https://pipenv-fork.readthedocs.io/en/latest/advanced.html#changing-default-python-versions):

```By default, Pipenv will initialize a project using whatever version of python the python3 is.```

This results in pipenv using the OS's default python version instead of the one configured on the setup python task via actions/setup-python.

Job example with this issue: https://github.com/gojek/merlin/actions/runs/3910409680/jobs/6682581939

This PR also pins numpy version due to [a backward incompatibility issue](https://numpy.org/doc/stable/release/1.20.0-notes.html#numpy-1-20-0-release-notes) with Merlin's required MLflow version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes Pipenv running on a different Python version than the host's Python version.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
