### PR TITLE
Refresh credentials in SDK on load

### DIFF
--- a/python/sdk/merlin/client.py
+++ b/python/sdk/merlin/client.py
@@ -18,8 +18,16 @@ from typing import Dict, List, Optional
 
 import google.auth
 import urllib3
-from client import (ApiClient, Configuration, EndpointApi, EnvironmentApi,
-                    ModelsApi, ProjectApi, VersionApi)
+from client import (
+    ApiClient,
+    Configuration,
+    EndpointApi,
+    EnvironmentApi,
+    ModelsApi,
+    ProjectApi,
+    VersionApi,
+)
+from google.auth.transport.requests import Request
 from google.auth.transport.urllib3 import AuthorizedHttp
 from merlin.autoscaling import AutoscalingPolicy
 from merlin.deployment_mode import DeploymentMode
@@ -33,22 +41,26 @@ from merlin.transformer import Transformer
 from merlin.util import valid_name_check
 from merlin.version import VERSION
 
-OAUTH_SCOPES = ['https://www.googleapis.com/auth/userinfo.email']
+OAUTH_SCOPES = ["https://www.googleapis.com/auth/userinfo.email"]
 
 
 class MerlinClient:
-    def __init__(self, merlin_url: str, use_google_oauth: bool=True):
+    def __init__(self, merlin_url: str, use_google_oauth: bool = True):
         self._merlin_url = merlin_url
         config = Configuration()
         config.host = self._merlin_url + "/v1"
 
         self._api_client = ApiClient(config)
         if use_google_oauth:
-            credentials, project = google.auth.default(scopes=OAUTH_SCOPES)
-            autorized_http = AuthorizedHttp(credentials, urllib3.PoolManager())
-            self._api_client.rest_client.pool_manager = autorized_http
+            # Load default credentials
+            credentials, _ = google.auth.default(scopes=OAUTH_SCOPES)
+            # Refresh credentials, in case it's coming from Compute Engine.
+            # See: https://github.com/googleapis/google-auth-library-python/issues/1211
+            credentials.refresh(Request())
+            authorized_http = AuthorizedHttp(credentials, urllib3.PoolManager())
+            self._api_client.rest_client.pool_manager = authorized_http
 
-        python_version = f'{version_info.major}.{version_info.minor}.{version_info.micro}'  # capture user's python version
+        python_version = f"{version_info.major}.{version_info.minor}.{version_info.micro}"  # capture user's python version
         self._api_client.user_agent = f"merlin-sdk/{VERSION} python/{python_version}"
         self._project_api = ProjectApi(self._api_client)
         self._model_api = ModelsApi(self._api_client)
@@ -71,7 +83,6 @@ class MerlinClient:
         for env in env_list:
             envs.append(Environment(env))
         return envs
-
 
     def get_environment(self, env_name: str) -> Optional[Environment]:
         """
@@ -126,12 +137,12 @@ class MerlinClient:
         """
         if not valid_name_check(project_name):
             raise ValueError(
-                '''Your project/model name contains invalid characters.\
+                """Your project/model name contains invalid characters.\
                     \nUse only the following characters\
                     \n- Characters: a-z (Lowercase ONLY)\
                     \n- Numbers: 0-9\
                     \n- Symbols: -
-                '''
+                """
             )
 
         p_list = self._project_api.projects_get(name=project_name)
@@ -141,14 +152,15 @@ class MerlinClient:
                 p = prj
 
         if p is None:
-            raise Exception(f"{project_name} does not exist or you don't have access to the project. Please create new "
-                            f"project using MLP console or ask the project's administrator to be able to access "
-                            f"existing project.")
+            raise Exception(
+                f"{project_name} does not exist or you don't have access to the project. Please create new "
+                f"project using MLP console or ask the project's administrator to be able to access "
+                f"existing project."
+            )
 
         return Project(p, self.url, self._api_client)
 
-    def get_model(self, model_name: str, project_name: str) \
-            -> Optional[Model]:
+    def get_model(self, model_name: str, project_name: str) -> Optional[Model]:
         """
         Get model with given name
 
@@ -158,7 +170,8 @@ class MerlinClient:
         """
         prj = self.get_project(project_name)
         m_list = self._model_api.projects_project_id_models_get(
-            project_id=int(prj.id), name=model_name)
+            project_id=int(prj.id), name=model_name
+        )
         model = m_list[0]
         if len(m_list) == 0:
             return None
@@ -169,9 +182,9 @@ class MerlinClient:
 
         return Model(model, prj, self._api_client)
 
-    def get_or_create_model(self, model_name: str,
-                            project_name: str,
-                            model_type: ModelType = None) -> Model:
+    def get_or_create_model(
+        self, model_name: str, project_name: str, model_type: ModelType = None
+    ) -> Model:
         """
         Get or create a model under a project
 
@@ -186,17 +199,18 @@ class MerlinClient:
         """
         if not valid_name_check(model_name):
             raise ValueError(
-                '''Your project/model name contains invalid characters.\
+                """Your project/model name contains invalid characters.\
                     \nUse only the following characters\
                     \n- Characters: a-z (Lowercase ONLY)\
                     \n- Numbers: 0-9\
                     \n- Symbols: -
-                '''
+                """
             )
 
         prj = self.get_project(project_name)
         m_list = self._model_api.projects_project_id_models_get(
-            project_id=int(prj.id), name=model_name)
+            project_id=int(prj.id), name=model_name
+        )
 
         model = None
         for mdl in m_list:
@@ -205,18 +219,20 @@ class MerlinClient:
 
         if model is None:
             if model_type is None:
-                raise ValueError(f"model {model_name} is not found, specify "
-                                 f"{model_type} to create it")
+                raise ValueError(
+                    f"model {model_name} is not found, specify "
+                    f"{model_type} to create it"
+                )
             model = self._model_api.projects_project_id_models_post(
-                project_id=int(prj.id), body={
-                    "name": model_name,
-                    "type": model_type.value
-                })
+                project_id=int(prj.id),
+                body={"name": model_name, "type": model_type.value},
+            )
 
         return Model(model, prj, self._api_client)
 
-    def new_model_version(self, model_name: str, project_name: str, labels: Dict[str, str] = None) \
-            -> ModelVersion:
+    def new_model_version(
+        self, model_name: str, project_name: str, labels: Dict[str, str] = None
+    ) -> ModelVersion:
         """
         Create new model version for the given model and project
 
@@ -230,18 +246,28 @@ class MerlinClient:
             raise ValueError(f"Model with name: {model_name} is not found")
         return mdl.new_model_version(labels=labels)
 
-    def deploy(self, model_version: ModelVersion,
-               environment_name: str = None,
-               resource_request: ResourceRequest = None,
-               env_vars: Dict[str, str] = None,
-               transformer: Transformer = None,
-               logger: Logger = None,
-               deployment_mode: DeploymentMode = DeploymentMode.SERVERLESS,
-               autoscaling_policy: AutoscalingPolicy = None,
-               protocol: Protocol = Protocol.HTTP_JSON) -> VersionEndpoint:
-        return model_version.deploy(environment_name, resource_request, env_vars, transformer, logger, deployment_mode,
-                                    autoscaling_policy, protocol)
+    def deploy(
+        self,
+        model_version: ModelVersion,
+        environment_name: str = None,
+        resource_request: ResourceRequest = None,
+        env_vars: Dict[str, str] = None,
+        transformer: Transformer = None,
+        logger: Logger = None,
+        deployment_mode: DeploymentMode = DeploymentMode.SERVERLESS,
+        autoscaling_policy: AutoscalingPolicy = None,
+        protocol: Protocol = Protocol.HTTP_JSON,
+    ) -> VersionEndpoint:
+        return model_version.deploy(
+            environment_name,
+            resource_request,
+            env_vars,
+            transformer,
+            logger,
+            deployment_mode,
+            autoscaling_policy,
+            protocol,
+        )
 
-    def undeploy(self, model_version: ModelVersion,
-                 environment_name: str = None):
+    def undeploy(self, model_version: ModelVersion, environment_name: str = None):
         model_version.undeploy(environment_name)

--- a/python/sdk/merlin/client.py
+++ b/python/sdk/merlin/client.py
@@ -18,15 +18,8 @@ from typing import Dict, List, Optional
 
 import google.auth
 import urllib3
-from client import (
-    ApiClient,
-    Configuration,
-    EndpointApi,
-    EnvironmentApi,
-    ModelsApi,
-    ProjectApi,
-    VersionApi,
-)
+from client import (ApiClient, Configuration, EndpointApi, EnvironmentApi,
+                    ModelsApi, ProjectApi, VersionApi)
 from google.auth.transport.requests import Request
 from google.auth.transport.urllib3 import AuthorizedHttp
 from merlin.autoscaling import AutoscalingPolicy
@@ -41,18 +34,17 @@ from merlin.transformer import Transformer
 from merlin.util import valid_name_check
 from merlin.version import VERSION
 
-OAUTH_SCOPES = ["https://www.googleapis.com/auth/userinfo.email"]
+OAUTH_SCOPES = ['https://www.googleapis.com/auth/userinfo.email']
 
 
 class MerlinClient:
-    def __init__(self, merlin_url: str, use_google_oauth: bool = True):
+    def __init__(self, merlin_url: str, use_google_oauth: bool=True):
         self._merlin_url = merlin_url
         config = Configuration()
         config.host = self._merlin_url + "/v1"
 
         self._api_client = ApiClient(config)
         if use_google_oauth:
-            # Load default credentials
             credentials, _ = google.auth.default(scopes=OAUTH_SCOPES)
             # Refresh credentials, in case it's coming from Compute Engine.
             # See: https://github.com/googleapis/google-auth-library-python/issues/1211
@@ -60,7 +52,7 @@ class MerlinClient:
             authorized_http = AuthorizedHttp(credentials, urllib3.PoolManager())
             self._api_client.rest_client.pool_manager = authorized_http
 
-        python_version = f"{version_info.major}.{version_info.minor}.{version_info.micro}"  # capture user's python version
+        python_version = f'{version_info.major}.{version_info.minor}.{version_info.micro}'  # capture user's python version
         self._api_client.user_agent = f"merlin-sdk/{VERSION} python/{python_version}"
         self._project_api = ProjectApi(self._api_client)
         self._model_api = ModelsApi(self._api_client)
@@ -83,6 +75,7 @@ class MerlinClient:
         for env in env_list:
             envs.append(Environment(env))
         return envs
+
 
     def get_environment(self, env_name: str) -> Optional[Environment]:
         """
@@ -137,12 +130,12 @@ class MerlinClient:
         """
         if not valid_name_check(project_name):
             raise ValueError(
-                """Your project/model name contains invalid characters.\
+                '''Your project/model name contains invalid characters.\
                     \nUse only the following characters\
                     \n- Characters: a-z (Lowercase ONLY)\
                     \n- Numbers: 0-9\
                     \n- Symbols: -
-                """
+                '''
             )
 
         p_list = self._project_api.projects_get(name=project_name)
@@ -152,15 +145,14 @@ class MerlinClient:
                 p = prj
 
         if p is None:
-            raise Exception(
-                f"{project_name} does not exist or you don't have access to the project. Please create new "
-                f"project using MLP console or ask the project's administrator to be able to access "
-                f"existing project."
-            )
+            raise Exception(f"{project_name} does not exist or you don't have access to the project. Please create new "
+                            f"project using MLP console or ask the project's administrator to be able to access "
+                            f"existing project.")
 
         return Project(p, self.url, self._api_client)
 
-    def get_model(self, model_name: str, project_name: str) -> Optional[Model]:
+    def get_model(self, model_name: str, project_name: str) \
+            -> Optional[Model]:
         """
         Get model with given name
 
@@ -170,8 +162,7 @@ class MerlinClient:
         """
         prj = self.get_project(project_name)
         m_list = self._model_api.projects_project_id_models_get(
-            project_id=int(prj.id), name=model_name
-        )
+            project_id=int(prj.id), name=model_name)
         model = m_list[0]
         if len(m_list) == 0:
             return None
@@ -182,9 +173,9 @@ class MerlinClient:
 
         return Model(model, prj, self._api_client)
 
-    def get_or_create_model(
-        self, model_name: str, project_name: str, model_type: ModelType = None
-    ) -> Model:
+    def get_or_create_model(self, model_name: str,
+                            project_name: str,
+                            model_type: ModelType = None) -> Model:
         """
         Get or create a model under a project
 
@@ -199,18 +190,17 @@ class MerlinClient:
         """
         if not valid_name_check(model_name):
             raise ValueError(
-                """Your project/model name contains invalid characters.\
+                '''Your project/model name contains invalid characters.\
                     \nUse only the following characters\
                     \n- Characters: a-z (Lowercase ONLY)\
                     \n- Numbers: 0-9\
                     \n- Symbols: -
-                """
+                '''
             )
 
         prj = self.get_project(project_name)
         m_list = self._model_api.projects_project_id_models_get(
-            project_id=int(prj.id), name=model_name
-        )
+            project_id=int(prj.id), name=model_name)
 
         model = None
         for mdl in m_list:
@@ -219,20 +209,18 @@ class MerlinClient:
 
         if model is None:
             if model_type is None:
-                raise ValueError(
-                    f"model {model_name} is not found, specify "
-                    f"{model_type} to create it"
-                )
+                raise ValueError(f"model {model_name} is not found, specify "
+                                 f"{model_type} to create it")
             model = self._model_api.projects_project_id_models_post(
-                project_id=int(prj.id),
-                body={"name": model_name, "type": model_type.value},
-            )
+                project_id=int(prj.id), body={
+                    "name": model_name,
+                    "type": model_type.value
+                })
 
         return Model(model, prj, self._api_client)
 
-    def new_model_version(
-        self, model_name: str, project_name: str, labels: Dict[str, str] = None
-    ) -> ModelVersion:
+    def new_model_version(self, model_name: str, project_name: str, labels: Dict[str, str] = None) \
+            -> ModelVersion:
         """
         Create new model version for the given model and project
 
@@ -246,28 +234,18 @@ class MerlinClient:
             raise ValueError(f"Model with name: {model_name} is not found")
         return mdl.new_model_version(labels=labels)
 
-    def deploy(
-        self,
-        model_version: ModelVersion,
-        environment_name: str = None,
-        resource_request: ResourceRequest = None,
-        env_vars: Dict[str, str] = None,
-        transformer: Transformer = None,
-        logger: Logger = None,
-        deployment_mode: DeploymentMode = DeploymentMode.SERVERLESS,
-        autoscaling_policy: AutoscalingPolicy = None,
-        protocol: Protocol = Protocol.HTTP_JSON,
-    ) -> VersionEndpoint:
-        return model_version.deploy(
-            environment_name,
-            resource_request,
-            env_vars,
-            transformer,
-            logger,
-            deployment_mode,
-            autoscaling_policy,
-            protocol,
-        )
+    def deploy(self, model_version: ModelVersion,
+               environment_name: str = None,
+               resource_request: ResourceRequest = None,
+               env_vars: Dict[str, str] = None,
+               transformer: Transformer = None,
+               logger: Logger = None,
+               deployment_mode: DeploymentMode = DeploymentMode.SERVERLESS,
+               autoscaling_policy: AutoscalingPolicy = None,
+               protocol: Protocol = Protocol.HTTP_JSON) -> VersionEndpoint:
+        return model_version.deploy(environment_name, resource_request, env_vars, transformer, logger, deployment_mode,
+                                    autoscaling_policy, protocol)
 
-    def undeploy(self, model_version: ModelVersion, environment_name: str = None):
+    def undeploy(self, model_version: ModelVersion,
+                 environment_name: str = None):
         model_version.undeploy(environment_name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

When authentication is enabled and the Google Auth credentials are loaded, the SDK is now made to refresh the credentials, to get around the following issue which affects Compute Engine workload identity: https://github.com/googleapis/google-auth-library-python/issues/1211

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

The SDK will now be able to load the default Service Account correctly, on GCE. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Load Service Account from Google Compute Engine correctly when authenticating using SDK 
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
