### PR TITLE
Add graceful termination for pyfunc http server

### DIFF
--- a/python/pyfunc-server/run.sh
+++ b/python/pyfunc-server/run.sh
@@ -13,6 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+sigterm_handler() {
+  echo "Terminating.."
+  kill -TERM "$server_pid"
+  wait "$server_pid"
+}
+
+sigint_handler() {
+  echo "Terminating.."
+  kill -INT "$server_pid"
+  wait "$server_pid"
+}
+
+trap sigterm_handler SIGTERM
+trap sigint_handler SIGINT
 
 source activate merlin-model
-python -m pyfuncserver --model_dir ./model
+python -m pyfuncserver --model_dir ./model &
+
+server_pid=$!
+wait "$server_pid"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Currently, pyfunc server implementation will immediately quit after receiving termination signal from OS/Kubernetes. This is not ideal for event such as scale down or redeployment. 
This PR implements graceful termination as well as update `run.sh` to forward termination signal to the pyfunc server. 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->
None


**Checklist**

- [X] Added unit test, integration, and/or e2e tests
- [X] Tested locally