### PR TITLE
Fix sqlalchemy version in mlflow-docker file

### DIFF
--- a/mlflow/Dockerfile
+++ b/mlflow/Dockerfile
@@ -14,8 +14,10 @@ RUN pip install psycopg2-binary==2.8.6
 
 ARG BOTO3_VERSION=1.7.12
 ARG MLFLOW_VERSION=1.3.0
+ARG SQLALCHEMY_VERSION=1.4.46
 
 RUN pip install boto3==${BOTO3_VERSION}
+RUN pip install SQLAlchemy==${SQLALCHEMY_VERSION}
 RUN pip install mlflow==${MLFLOW_VERSION}
 
 ENV BACKEND_STORE_URI="/data/mlruns"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
The new release of [sqlalchemy](https://pypi.org/project/SQLAlchemy/#history) is causing this error when starting merlin-mlflow, example [workflow](https://github.com/gojek/merlin/actions/runs/4023217997/jobs/6913992234), the logs from the workflow here: https://pastebin.com/9QL4j8zK.

SQLAlchemy released a new version (2.0.0) on Jan 27, the last working version is 1.4.46.

This PR fixes the SQLAlchemy version to 1.4.46 in `mlflow/dockerfile`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
