### PR TITLE
Change authentication method to use OIDC identity tokens 

### DIFF
--- a/python/sdk/docs/requirements_docs.txt
+++ b/python/sdk/docs/requirements_docs.txt
@@ -17,7 +17,6 @@ mlflow>=1.2.0,<=1.23.0
 google-cloud-storage>=1.19.0
 urllib3>=1.23
 PyPrind>=2.11.2
-google-auth>=2.16.2
 Click>=7.0
 cloudpickle==2.0.0
 cookiecutter>=1.7.0

--- a/python/sdk/docs/requirements_docs.txt
+++ b/python/sdk/docs/requirements_docs.txt
@@ -17,7 +17,7 @@ mlflow>=1.2.0,<=1.23.0
 google-cloud-storage>=1.19.0
 urllib3>=1.23
 PyPrind>=2.11.2
-google-auth>=1.11.0,<2.0dev
+google-auth>=2.16.2
 Click>=7.0
 cloudpickle==2.0.0
 cookiecutter>=1.7.0

--- a/python/sdk/merlin/client.py
+++ b/python/sdk/merlin/client.py
@@ -22,6 +22,7 @@ from client import (ApiClient, Configuration, EndpointApi, EnvironmentApi,
                     ModelsApi, ProjectApi, VersionApi)
 from google.auth.transport.requests import Request
 from google.auth.transport.urllib3 import AuthorizedHttp
+from caraml_auth.id_token_credentials import get_default_id_token_credentials
 from merlin.autoscaling import AutoscalingPolicy
 from merlin.deployment_mode import DeploymentMode
 from merlin.endpoint import VersionEndpoint
@@ -45,7 +46,7 @@ class MerlinClient:
 
         self._api_client = ApiClient(config)
         if use_google_oauth:
-            credentials, _ = google.auth.default(scopes=OAUTH_SCOPES)
+            credentials = get_default_id_token_credentials(target_audience="turing-sdk.caraml")
             # Refresh credentials, in case it's coming from Compute Engine.
             # See: https://github.com/googleapis/google-auth-library-python/issues/1211
             credentials.refresh(Request())

--- a/python/sdk/merlin/client.py
+++ b/python/sdk/merlin/client.py
@@ -46,7 +46,7 @@ class MerlinClient:
 
         self._api_client = ApiClient(config)
         if use_google_oauth:
-            credentials = get_default_id_token_credentials(target_audience="turing-sdk.caraml")
+            credentials = get_default_id_token_credentials(target_audience="sdk.caraml")
             # Refresh credentials, in case it's coming from Compute Engine.
             # See: https://github.com/googleapis/google-auth-library-python/issues/1211
             credentials.refresh(Request())

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -39,7 +39,7 @@ REQUIRES = [
     "six>=1.10",
     "urllib3>=1.23",
     "numpy<=1.23.5", # Temporary pin numpy due to https://numpy.org/doc/stable/release/1.20.0-notes.html#numpy-1-20-0-release-notes
-    "caraml-auth-google @ git+https://github.com/caraml-dev/caraml-sdk.git@a662528#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google",
+    "caraml-auth-google==0.0.0.post3",
 ]
 
 TEST_REQUIRES = [

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -29,7 +29,6 @@ REQUIRES = [
     "cloudpickle==2.0.0",  # used by mlflow
     "cookiecutter>=1.7.2",
     "docker>=4.2.1",
-    "google-auth>=2.16.2",
     "google-cloud-storage>=1.19.0",
     "mlflow>=1.2.0,<=1.23.0", #  for py3.11 due to proto -> "mlflow>=1.26.1",
     "protobuf>=3.0.0,<4.0.0", #  for py3.11 due to proto -> "protobuf>=4.0.0,<5.0dev",

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -39,7 +39,7 @@ REQUIRES = [
     "six>=1.10",
     "urllib3>=1.23",
     "numpy<=1.23.5", # Temporary pin numpy due to https://numpy.org/doc/stable/release/1.20.0-notes.html#numpy-1-20-0-release-notes
-    "caraml-auth-google @ git+https://github.com/deadlycoconuts/caraml-sdk.git@add_openid_connect_id_tokens_utils#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google",
+    "caraml-auth-google @ git+https://github.com/caraml-dev/caraml-sdk.git@a662528#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google",
 ]
 
 TEST_REQUIRES = [

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -39,6 +39,7 @@ REQUIRES = [
     "six>=1.10",
     "urllib3>=1.23",
     "numpy<=1.23.5", # Temporary pin numpy due to https://numpy.org/doc/stable/release/1.20.0-notes.html#numpy-1-20-0-release-notes
+    "caraml-auth-google @ git+https://github.com/deadlycoconuts/caraml-sdk.git@add_openid_connect_id_tokens_utils#egg=caraml-auth-google&subdirectory=packages/caraml-auth-google",
 ]
 
 TEST_REQUIRES = [

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -29,7 +29,7 @@ REQUIRES = [
     "cloudpickle==2.0.0",  # used by mlflow
     "cookiecutter>=1.7.2",
     "docker>=4.2.1",
-    "google-auth>=1.11.0",
+    "google-auth>=2.16.2",
     "google-cloud-storage>=1.19.0",
     "mlflow>=1.2.0,<=1.23.0", #  for py3.11 due to proto -> "mlflow>=1.26.1",
     "protobuf>=3.0.0,<4.0.0", #  for py3.11 due to proto -> "protobuf>=4.0.0,<5.0dev",


### PR DESCRIPTION
**What this PR does / why we need it**:
As of present, authentication is performed by the Merlin and Turing SDKs using Google OAuth 2.0 access tokens (generated after authentication with Google's OAuth server) that are added to the headers of requests sent to the Turing API server. These tokens are then used by an internal proxy which will validate the access token and then retrieve the user profile information from the Google API. 

However, in keeping with the move of the Google Identity Services client library from OAuth 2.0 access tokens to Google OpenID Connect (OIDC) identity tokens, we are similarly replacing the use of the former for the latter. These tokens generated would similarly be added to the headers of requests sent to the Turing API server to be validated internally. 

A utils module `caraml_auth` in the package `caraml-auth-google` has been created in the CaraML SDK [repository](https://github.com/caraml-dev/caraml-sdk) to provide this new method of authentication.

This PR serves to update the existing authentication method used by the Turing SDK.

**Which issue(s) this PR fixes**:
The Merlin SDK will import and use the function `get_default_id_token_credentials` provided by the `caraml-auth-google` package:

```python
from caraml_auth.id_token_credentials import get_default_id_token_credentials

credentials = get_default_id_token_credentials(target_audience="sdk.caraml")
credentials.refresh(Request())
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```


**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
