### PR TITLE
Remove oauth scope warning and redundant oauth scope

### DIFF
--- a/python/sdk/merlin/client.py
+++ b/python/sdk/merlin/client.py
@@ -35,8 +35,6 @@ from merlin.transformer import Transformer
 from merlin.util import valid_name_check
 from merlin.version import VERSION
 
-OAUTH_SCOPES = ['https://www.googleapis.com/auth/userinfo.email']
-
 
 class MerlinClient:
     def __init__(self, merlin_url: str, use_google_oauth: bool=True):

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -38,7 +38,7 @@ REQUIRES = [
     "six>=1.10",
     "urllib3>=1.23",
     "numpy<=1.23.5", # Temporary pin numpy due to https://numpy.org/doc/stable/release/1.20.0-notes.html#numpy-1-20-0-release-notes
-    "caraml-auth-google==0.0.0.post3",
+    "caraml-auth-google==0.0.0.post4",
 ]
 
 TEST_REQUIRES = [


### PR DESCRIPTION
**What this PR does / why we need it**:
When the Merlin SDK is used to authenticate a user with a user account, the warning `Not all requested scopes were granted by the authorization server, missing scopes email.` gets thrown because the scope specified for the email field was stated as `email` instead of `https://www.googleapis.com/auth/userinfo.email` (see https://developers.google.com/identity/protocols/oauth2/scopes#oauth2 for more info).

The relevant change has already been made in https://github.com/caraml-dev/caraml-sdk/pull/3, and this PR makes a change to the version of `caraml-auth-google` to incorporate those changes. The unused constant `OAUTH_SCOPES` has also been removed from the SDK in the process.

Thanks @ariefrahmansyah for catching this!

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
