### PR TITLE
Remove resource_request for custom transformer test to avoid OOMKilled

### DIFF
--- a/python/sdk/test/integration_test.py
+++ b/python/sdk/test/integration_test.py
@@ -418,8 +418,6 @@ def test_logger(integration_test_url, project_name, deployment_mode, use_google_
     merlin.undeploy(v)
 
 
-# https://github.com/kserve/kserve/issues/2142
-# Logging is not supported yet in raw_deployment
 @pytest.mark.customtransformer
 @pytest.mark.integration
 @pytest.mark.parametrize("deployment_mode", [DeploymentMode.RAW_DEPLOYMENT, DeploymentMode.SERVERLESS])
@@ -432,10 +430,8 @@ def test_custom_transformer(
 
     undeploy_all_version()
 
-    resource_request = ResourceRequest(1, 1, "50m", "200Mi")
     transformer = Transformer(
         "gcr.io/kubeflow-ci/kfserving/image-transformer:latest",
-        resource_request=resource_request,
     )
 
     logger = Logger(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

test/integration_test.py::test_custom_transformer is flaky and sometimes fails due to the transformer pod getting OOMKilled. This PR removes the resource_request so the deployment will use the environment's default value.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
